### PR TITLE
[feat] Google 기반 Oauth2 설정 및 Jwt기반 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,20 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // OAuth 관련 라이브러리
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // jwt 관련 라이브러리
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
+    // ConfigurationProperties 관련 라이브러리
+    implementation 'org.springframework.boot:spring-boot-configuration-processor'
+
+
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
@@ -32,4 +46,8 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+tasks.named('compileJava') {
+    inputs.files(tasks.named('processResources'))
 }

--- a/src/main/java/com/kusitms/samsion/SamsionApplication.java
+++ b/src/main/java/com/kusitms/samsion/SamsionApplication.java
@@ -2,8 +2,14 @@ package com.kusitms.samsion;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import com.kusitms.samsion.common.security.jwt.JwtProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(JwtProperties.class)
+@EnableJpaAuditing
 public class SamsionApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/kusitms/samsion/common/config/SecurityConfig.java
+++ b/src/main/java/com/kusitms/samsion/common/config/SecurityConfig.java
@@ -1,0 +1,46 @@
+package com.kusitms.samsion.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.kusitms.samsion.common.security.jwt.JwtAuthenticationEntryPoint;
+import com.kusitms.samsion.common.security.jwt.JwtAuthenticationFilter;
+import com.kusitms.samsion.common.security.oauth.CustomOAuth2UserService;
+import com.kusitms.samsion.common.security.oauth.OAuth2SuccessHandler;
+
+import lombok.RequiredArgsConstructor;
+
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final CustomOAuth2UserService customOAuth2UserService;
+	private final OAuth2SuccessHandler oAuth2SuccessHandler;
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+	/**
+	 * TODO : OAuth2FailureHandler 추가하기
+	 */
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http.oauth2Login(
+				oauth2Login -> oauth2Login
+					.successHandler(oAuth2SuccessHandler)
+					.userInfoEndpoint().userService(customOAuth2UserService)
+		);
+		http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+		http.authorizeRequests().anyRequest().authenticated();
+		http.cors();
+
+		http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+		http.addFilterBefore(jwtAuthenticationEntryPoint, JwtAuthenticationFilter.class);
+		return http.build();
+	}
+
+
+}

--- a/src/main/java/com/kusitms/samsion/common/consts/ApplicationStatic.java
+++ b/src/main/java/com/kusitms/samsion/common/consts/ApplicationStatic.java
@@ -1,0 +1,12 @@
+package com.kusitms.samsion.common.consts;
+
+public class ApplicationStatic {
+	public static final String ACCESS_TOKEN = "ACCESS_TOKEN";
+	public static final String REFRESH_TOKEN = "REFRESH_TOKEN";
+	public static final String TOKEN_TYPE = "TOKEN_TYPE";
+
+	public static final String JWT_AUTHORIZATION_TYPE = "Bearer"+" ";
+
+	public static final String ACCESS_TOKEN_HEADER = "Authorization";
+	public static final String REFRESH_TOKEN_HEADER = "RefreshToken";
+}

--- a/src/main/java/com/kusitms/samsion/common/domain/BaseEntity.java
+++ b/src/main/java/com/kusitms/samsion/common/domain/BaseEntity.java
@@ -1,0 +1,29 @@
+package com.kusitms.samsion.common.domain;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+	@CreatedDate
+	private LocalDateTime createdDate;
+
+	@LastModifiedDate
+	private LocalDateTime modifiedDate;
+
+	public LocalDateTime getCreatedDate() {
+		return createdDate;
+	}
+
+	public LocalDateTime getModifiedDate() {
+		return modifiedDate;
+	}
+}

--- a/src/main/java/com/kusitms/samsion/common/exception/BusinessException.java
+++ b/src/main/java/com/kusitms/samsion/common/exception/BusinessException.java
@@ -1,0 +1,16 @@
+package com.kusitms.samsion.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException{
+
+	private Error error;
+
+	public BusinessException(Error error) {
+		this.error = error;
+	}
+
+
+
+}

--- a/src/main/java/com/kusitms/samsion/common/exception/Error.java
+++ b/src/main/java/com/kusitms/samsion/common/exception/Error.java
@@ -1,0 +1,19 @@
+package com.kusitms.samsion.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum Error {
+
+	// JWT
+	INVALID_TOKEN("잘못된 토큰 요청", 401),
+	EXPIRED_TOKEN("토큰 만료", 402);
+
+	private final String message;
+	private final int errorCode;
+
+	Error(String message, int errorCode) {
+		this.message = message;
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/kusitms/samsion/common/security/exception/ExpiredTokenException.java
+++ b/src/main/java/com/kusitms/samsion/common/security/exception/ExpiredTokenException.java
@@ -1,0 +1,9 @@
+package com.kusitms.samsion.common.security.exception;
+
+import com.kusitms.samsion.common.exception.Error;
+
+public class ExpiredTokenException extends JwtException{
+	public ExpiredTokenException(Error error) {
+		super(error);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/common/security/exception/InvalidTokenException.java
+++ b/src/main/java/com/kusitms/samsion/common/security/exception/InvalidTokenException.java
@@ -1,0 +1,10 @@
+package com.kusitms.samsion.common.security.exception;
+
+import com.kusitms.samsion.common.exception.Error;
+
+public class InvalidTokenException extends JwtException{
+
+	public InvalidTokenException(Error error) {
+		super(error);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/common/security/exception/JwtException.java
+++ b/src/main/java/com/kusitms/samsion/common/security/exception/JwtException.java
@@ -1,0 +1,10 @@
+package com.kusitms.samsion.common.security.exception;
+
+import com.kusitms.samsion.common.exception.BusinessException;
+import com.kusitms.samsion.common.exception.Error;
+
+public class JwtException extends BusinessException {
+	public JwtException(Error error) {
+		super(error);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/common/security/exception/TokenNotFoundException.java
+++ b/src/main/java/com/kusitms/samsion/common/security/exception/TokenNotFoundException.java
@@ -1,0 +1,9 @@
+package com.kusitms.samsion.common.security.exception;
+
+import com.kusitms.samsion.common.exception.Error;
+
+public class TokenNotFoundException extends JwtException {
+	public TokenNotFoundException(Error error) {
+		super(error);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/common/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/kusitms/samsion/common/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,60 @@
+package com.kusitms.samsion.common.security.jwt;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kusitms.samsion.common.security.exception.JwtException;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * TODO : 에러 반환시에 사용자 정보를 로그로 남기기(?)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint extends OncePerRequestFilter {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+			throws ServletException, IOException {
+		try{
+			filterChain.doFilter(request, response);
+		} catch (JwtException e){
+			log.info("JwtException: {} {}",e.getError().getMessage(), e.getError().getErrorCode());
+			setErrorCode(response, e.getError().getErrorCode());
+		}
+	}
+
+	private void setErrorCode(HttpServletResponse response, int errorCode) throws IOException {
+		ErrorResponse errorResponse = ErrorResponse.builder()
+			.errorCode(errorCode)
+			.build();
+		response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+		response.setContentType("application/json");
+		response.setCharacterEncoding("UTF-8");
+		response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+	}
+
+	@Getter
+	private static class ErrorResponse{
+		private final int errorCode;
+		@Builder
+		public ErrorResponse(int errorCode) {
+			this.errorCode = errorCode;
+		}
+	}
+}

--- a/src/main/java/com/kusitms/samsion/common/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kusitms/samsion/common/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package com.kusitms.samsion.common.security.jwt;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.kusitms.samsion.common.consts.ApplicationStatic;
+import com.kusitms.samsion.common.exception.Error;
+import com.kusitms.samsion.common.security.exception.TokenNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * TODO : Authorities 설정 변경 필요 (현재는 ROLE_USER로 고정, enum으로 관리 필요)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtProvider jwtProvider;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		final String header = request.getHeader(ApplicationStatic.ACCESS_TOKEN_HEADER);
+		validateAuthorizationHeader(header);
+
+		final String accessToken = validateAccessToken(header);
+		setAuthentication(accessToken);
+
+		filterChain.doFilter(request, response);
+	}
+
+	private void validateAuthorizationHeader(final String header) {
+		if (header == null || !header.startsWith(ApplicationStatic.JWT_AUTHORIZATION_TYPE)) {
+			throw new TokenNotFoundException(Error.INVALID_TOKEN);
+		}
+	}
+
+	private String validateAccessToken(final String header) {
+		final String accessToken = header.replace(ApplicationStatic.JWT_AUTHORIZATION_TYPE, "");
+		jwtProvider.validateToken(accessToken);
+		return accessToken;
+	}
+
+	private void setAuthentication(final String accessToken){
+		final String email = jwtProvider.extractEmail(accessToken);
+		List<GrantedAuthority> grantedAuthorities = Collections.singletonList(
+			new SimpleGrantedAuthority("ROLE_USER"));
+		JwtAuthenticationToken authentication = new JwtAuthenticationToken(grantedAuthorities, email);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/common/security/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/kusitms/samsion/common/security/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,27 @@
+package com.kusitms.samsion.common.security.jwt;
+
+import java.util.Collection;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+	private String email;
+
+	public JwtAuthenticationToken(Collection<? extends GrantedAuthority> authorities, String email) {
+		super(authorities);
+		this.email = email;
+		setAuthenticated(true);
+	}
+
+	@Override
+	public Object getCredentials() {
+		return null;
+	}
+
+	@Override
+	public Object getPrincipal() {
+		return email;
+	}
+}

--- a/src/main/java/com/kusitms/samsion/common/security/jwt/JwtProperties.java
+++ b/src/main/java/com/kusitms/samsion/common/security/jwt/JwtProperties.java
@@ -1,0 +1,17 @@
+package com.kusitms.samsion.common.security.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@ConstructorBinding
+@ConfigurationProperties(prefix = "auth.jwt")
+public class JwtProperties {
+	private final String secret;
+	private final long accessTokenPeriod;
+	private final long refreshTokenPeriod;
+}

--- a/src/main/java/com/kusitms/samsion/common/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/kusitms/samsion/common/security/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,61 @@
+package com.kusitms.samsion.common.security.oauth;
+
+import java.util.Collections;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import com.kusitms.samsion.domain.user.entity.User;
+import com.kusitms.samsion.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+	private final UserRepository userRepository;
+
+	/**
+	 * TODO : 코드 리팩터링, 예외처리 추가하기, kakao, naver 로그인 추가하기 , Authorities 설정 변경 필요 (현재는 ROLE_USER로 고정, enum으로 관리 필요)
+	 * CustomOAuth2UserService 클래스를 통해서 구글 로그인 이후 가져온 사용자의 정보(email, name, picture)들을 기반으로 가입
+	 */
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		DefaultOAuth2UserService oAuth2UserService = new DefaultOAuth2UserService();
+		OAuth2User oAuth2User = oAuth2UserService.loadUser(userRequest);
+
+		ClientRegistration clientRegistration = userRequest.getClientRegistration();
+
+		String registrationId = clientRegistration.getRegistrationId();
+		String userNameAttributeName = clientRegistration.getProviderDetails()
+			.getUserInfoEndpoint()
+			.getUserNameAttributeName();
+
+		OAuth2Attributes attributes = OAuth2Attributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+
+		saveOrUpdate(attributes);
+
+		return new DefaultOAuth2User(Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+			, attributes.getAttributes()
+			, attributes.getNameAttributeKey());
+	}
+
+	private void saveOrUpdate(OAuth2Attributes attributes) {
+		User user = userRepository.findByEmail(attributes.getEmail())
+			.map(entity -> entity.update(attributes.getName(), attributes.getImageUrl()))
+			.orElse(attributes.toEntity());
+
+		userRepository.save(user);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/common/security/oauth/OAuth2Attributes.java
+++ b/src/main/java/com/kusitms/samsion/common/security/oauth/OAuth2Attributes.java
@@ -1,0 +1,55 @@
+package com.kusitms.samsion.common.security.oauth;
+
+import java.util.Map;
+
+import com.kusitms.samsion.domain.user.entity.User;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * TODO : kakao, naver 로그인 추가하기
+ */
+@Getter
+public class OAuth2Attributes {
+	private Map<String, Object> attributes;
+	private String nameAttributeKey;
+	private String name;
+	private String email;
+	private String imageUrl;
+
+	@Builder
+	public OAuth2Attributes(Map<String, Object> attributes, String nameAttributeKey, String name, String email,
+		String imageUrl) {
+		this.attributes = attributes;
+		this.nameAttributeKey = nameAttributeKey;
+		this.name = name;
+		this.email = email;
+		this.imageUrl = imageUrl;
+	}
+
+	public OAuth2Attributes() {
+	}
+
+	public static OAuth2Attributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
+		return ofGoogle(userNameAttributeName, attributes);
+	}
+
+	private static OAuth2Attributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+		return OAuth2Attributes.builder()
+			.attributes(attributes)
+			.nameAttributeKey(userNameAttributeName)
+			.name((String) attributes.get("name"))
+			.email((String) attributes.get("email"))
+			.imageUrl((String) attributes.get("picture"))
+			.build();
+	}
+
+	public User toEntity() {
+		return User.builder()
+			.nickname(name)
+			.email(email)
+			.imageUrl(imageUrl)
+			.build();
+	}
+}

--- a/src/main/java/com/kusitms/samsion/common/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/kusitms/samsion/common/security/oauth/OAuth2SuccessHandler.java
@@ -1,0 +1,41 @@
+package com.kusitms.samsion.common.security.oauth;
+
+import static com.kusitms.samsion.common.consts.ApplicationStatic.*;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import com.kusitms.samsion.common.security.jwt.JwtProvider;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * TODO : 현제 토큰 생성에서 email 정보만을 담고있음. 추후에 유저 역할(ROLE_USER)등 정보를 추가할지 고민.
+ */
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+	private final JwtProvider jwtProvider;
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication){
+		OAuth2User oAuth2User = (OAuth2User)authentication.getPrincipal();
+		generateToken(oAuth2User.getAttribute("email"), response);
+	}
+
+	private void generateToken(String email, HttpServletResponse response){
+		String accessToken = jwtProvider.generateAccessToken(email);
+		String refreshToken = jwtProvider.generateRefreshToken(email);
+
+		response.setHeader(ACCESS_TOKEN_HEADER, JWT_AUTHORIZATION_TYPE+accessToken);
+		response.setHeader(REFRESH_TOKEN_HEADER, JWT_AUTHORIZATION_TYPE+refreshToken);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/user/entity/User.java
+++ b/src/main/java/com/kusitms/samsion/domain/user/entity/User.java
@@ -1,0 +1,52 @@
+package com.kusitms.samsion.domain.user.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import com.kusitms.samsion.common.domain.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+	@Id@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "user_id")
+	private Long id;
+
+	private String nickname;
+	private String email;
+	private String imageUrl;
+
+
+	@Builder
+	public User(String nickname, String email, String imageUrl) {
+		this.nickname = nickname;
+		this.email = email;
+		this.imageUrl = imageUrl;
+	}
+
+	public User update(String nickname, String imageUrl) {
+		this.nickname = nickname;
+		this.imageUrl = imageUrl;
+		return this;
+	}
+
+	@Override
+	public String toString() {
+		return "User{" +
+			"id=" + id +
+			", nickname='" + nickname + '\'' +
+			", email='" + email + '\'' +
+			", imageUrl='" + imageUrl +
+			'}';
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kusitms/samsion/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.kusitms.samsion.domain.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kusitms.samsion.domain.user.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+	Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/kusitms/samsion/infrastructure/redis/RedisConfig.java
+++ b/src/main/java/com/kusitms/samsion/infrastructure/redis/RedisConfig.java
@@ -1,0 +1,33 @@
+package com.kusitms.samsion.infrastructure.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+	@Value("${spring.redis.host}")
+	private String host;
+
+	@Value("${spring.redis.port}")
+	private int port;
+
+	/**
+	 * 기존 jpa의 인터페이스 선언방식으로 redis을 사용하기 위해서 redisConnectionFactory를 빈으로 등록한다.
+	 */
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory(){
+		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public RedisTemplate<?, ?> redisTemplate(){
+		RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		return redisTemplate;
+	}
+}


### PR DESCRIPTION
# Summary

---

1. OAuth2을 우선 google만 추가함.
2. OAuth2에서 로그인 성공하면 해당 인증 서버에서 받은 사용자 정보(email)을 이용해서 AccessToken, RefreshToken 발급.
3. Refresh Token 발급시에 redis에 캐싱함.
4. 토큰 인증과정에서 예외 발생하면 entrypoint 클래스를 통해서 에러 코드 반환

# Issue

---

#8

# References

---


