### PR TITLE
[feat] Ignored Path 설정 및 AccessToken 재발급 기능 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,7 +36,7 @@ jobs:
         shell: bash
 
       - name: Build With Gradle
-        run: ./gradlew build -x test
+        run: ./gradlew build
 
 
       - name: Docker build & Push

--- a/src/main/java/com/kusitms/samsion/application/auth/service/AuthReIssueService.java
+++ b/src/main/java/com/kusitms/samsion/application/auth/service/AuthReIssueService.java
@@ -1,0 +1,24 @@
+package com.kusitms.samsion.application.auth.service;
+
+import com.kusitms.samsion.common.annotation.ApplicationService;
+import com.kusitms.samsion.common.consts.ApplicationConst;
+import com.kusitms.samsion.common.security.jwt.JwtProvider;
+import com.kusitms.samsion.common.util.HeaderUtils;
+import com.kusitms.samsion.common.util.SecurityUtils;
+
+import lombok.RequiredArgsConstructor;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class AuthReIssueService {
+
+	private final JwtProvider jwtProvider;
+
+	public void reissue() {
+		final String refreshTokenHeader = HeaderUtils.getHeader(ApplicationConst.REFRESH_TOKEN_HEADER);
+		final String refreshToken = SecurityUtils.validateHeaderAndGetToken(refreshTokenHeader);
+		final String accessToken = jwtProvider.reIssue(refreshToken);
+		HeaderUtils.setHeader(ApplicationConst.ACCESS_TOKEN_HEADER, ApplicationConst.JWT_AUTHORIZATION_TYPE + accessToken);
+	}
+
+}

--- a/src/main/java/com/kusitms/samsion/common/annotation/ApplicationService.java
+++ b/src/main/java/com/kusitms/samsion/common/annotation/ApplicationService.java
@@ -1,0 +1,14 @@
+package com.kusitms.samsion.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.stereotype.Service;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Service
+public @interface ApplicationService {
+}

--- a/src/main/java/com/kusitms/samsion/common/annotation/DomainService.java
+++ b/src/main/java/com/kusitms/samsion/common/annotation/DomainService.java
@@ -1,0 +1,14 @@
+package com.kusitms.samsion.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.stereotype.Service;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Service
+public @interface DomainService {
+}

--- a/src/main/java/com/kusitms/samsion/common/consts/ApplicationConst.java
+++ b/src/main/java/com/kusitms/samsion/common/consts/ApplicationConst.java
@@ -1,6 +1,10 @@
 package com.kusitms.samsion.common.consts;
 
-public class ApplicationStatic {
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ApplicationConst {
 	public static final String ACCESS_TOKEN = "ACCESS_TOKEN";
 	public static final String REFRESH_TOKEN = "REFRESH_TOKEN";
 	public static final String TOKEN_TYPE = "TOKEN_TYPE";

--- a/src/main/java/com/kusitms/samsion/common/consts/IgnoredPathConst.java
+++ b/src/main/java/com/kusitms/samsion/common/consts/IgnoredPathConst.java
@@ -1,0 +1,14 @@
+package com.kusitms.samsion.common.consts;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class IgnoredPathConst {
+
+	public static final String[] IGNORED_PATHS = {
+			"/oauth2/**",
+			"/info",
+			"/auth/reissue",
+			"/favicon.ico"};
+}

--- a/src/main/java/com/kusitms/samsion/common/security/jwt/JwtProvider.java
+++ b/src/main/java/com/kusitms/samsion/common/security/jwt/JwtProvider.java
@@ -87,9 +87,10 @@ public class JwtProvider {
 	}
 
 	/**
+	 * TODO : 예외 처리 관련해서 좀 더 고민해보기
 	 * @throws InvalidTokenException : 유효하지 않은 토큰
 	 * @throws ExpiredTokenException : 만료된 토큰
-	 * @throws IllegalArgumentException : 토큰이 null일 경우, 하지만 헤더에서 토큰을 가져오는 과정에서 이미 null인지 검사하므로 발생하지 않음(ignore)
+	 * @throws IllegalArgumentException : 토큰이 null일 경우
 	 */
 	public void validateToken(String token) {
 		JwtParser jwtParser = Jwts.parserBuilder()
@@ -97,11 +98,10 @@ public class JwtProvider {
 			.build();
 		try {
 			jwtParser.parse(token);
-		} catch (MalformedJwtException | SignatureException e){
+		} catch (MalformedJwtException | SignatureException | IllegalArgumentException e){
 			throw new InvalidTokenException(Error.INVALID_TOKEN);
 		} catch (ExpiredJwtException e){
 			throw new ExpiredTokenException(Error.EXPIRED_TOKEN);
-		} catch (IllegalArgumentException ignore){
 		}
 	}
 

--- a/src/main/java/com/kusitms/samsion/common/security/jwt/JwtProvider.java
+++ b/src/main/java/com/kusitms/samsion/common/security/jwt/JwtProvider.java
@@ -1,6 +1,6 @@
 package com.kusitms.samsion.common.security.jwt;
 
-import static com.kusitms.samsion.common.consts.ApplicationStatic.*;
+import static com.kusitms.samsion.common.consts.ApplicationConst.*;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
@@ -65,6 +65,10 @@ public class JwtProvider {
 			TimeUnit.MILLISECONDS);
 	}
 
+	private String getRefreshToken(String email) {
+		return redisTemplate.opsForValue().get(email);
+	}
+
 	private JwtBuilder buildToken(Date now) {
 		final Key key = getSecretKey();
 		return Jwts.builder()
@@ -109,5 +113,21 @@ public class JwtProvider {
 			.getBody()
 			.getSubject();
 	}
+
+	public String reIssue(String refreshToken){
+		String email = validateRefreshToken(refreshToken);
+		return generateAccessToken(email);
+	}
+
+	public String validateRefreshToken(String refreshToken) {
+		validateToken(refreshToken);
+		final String email = extractEmail(refreshToken);
+		final String storedRefreshToken = getRefreshToken(email);
+		if(!storedRefreshToken.equals(refreshToken)){
+			throw new InvalidTokenException(Error.INVALID_TOKEN);
+		}
+		return email;
+	}
+
 
 }

--- a/src/main/java/com/kusitms/samsion/common/util/HeaderUtils.java
+++ b/src/main/java/com/kusitms/samsion/common/util/HeaderUtils.java
@@ -1,0 +1,26 @@
+package com.kusitms.samsion.common.util;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * ServletUtils을 이용해서 HttpServletRequest, HttpServletResponse 가져올때 시간이 얼마나 걸리는지 확인.
+ * 시간이 너무 오래 걸리면 이 메소드를 사용하지 않고 파라미터로 HttpServletRequest, HttpServletResponse를 받아서 사용.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class HeaderUtils {
+
+	public static String getHeader(String headerName){
+		HttpServletRequest request = ServletUtils.getRequest();
+		return request.getHeader(headerName);
+	}
+
+	public static void setHeader(String headerName, String headerValue){
+		HttpServletResponse response = ServletUtils.getResponse();
+		response.setHeader(headerName, headerValue);
+	}
+
+}

--- a/src/main/java/com/kusitms/samsion/common/util/SecurityUtils.java
+++ b/src/main/java/com/kusitms/samsion/common/util/SecurityUtils.java
@@ -1,0 +1,24 @@
+package com.kusitms.samsion.common.util;
+
+import java.util.Optional;
+
+import org.springframework.util.StringUtils;
+
+import com.kusitms.samsion.common.consts.ApplicationConst;
+import com.kusitms.samsion.common.exception.Error;
+import com.kusitms.samsion.common.security.exception.TokenNotFoundException;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class SecurityUtils {
+
+	public static String validateHeaderAndGetToken(final String headerValue){
+		return Optional.ofNullable(headerValue)
+			.filter(header -> header.startsWith(ApplicationConst.JWT_AUTHORIZATION_TYPE))
+			.filter(StringUtils::hasText)
+			.map(header -> header.replace(ApplicationConst.JWT_AUTHORIZATION_TYPE, ""))
+			.orElseThrow(() -> new TokenNotFoundException(Error.INVALID_TOKEN));
+	}
+
+}

--- a/src/main/java/com/kusitms/samsion/common/util/ServletUtils.java
+++ b/src/main/java/com/kusitms/samsion/common/util/ServletUtils.java
@@ -1,0 +1,24 @@
+package com.kusitms.samsion.common.util;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public final class ServletUtils {
+
+	public static HttpServletRequest getRequest() {
+		ServletRequestAttributes servletRequestAttributes = (ServletRequestAttributes)RequestContextHolder.currentRequestAttributes();
+		return servletRequestAttributes.getRequest();
+	}
+
+	public static HttpServletResponse getResponse() {
+		ServletRequestAttributes servletRequestAttributes = (ServletRequestAttributes)RequestContextHolder.currentRequestAttributes();
+		return servletRequestAttributes.getResponse();
+	}
+
+}

--- a/src/main/java/com/kusitms/samsion/presentation/auth/AuthController.java
+++ b/src/main/java/com/kusitms/samsion/presentation/auth/AuthController.java
@@ -1,0 +1,23 @@
+package com.kusitms.samsion.presentation.auth;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kusitms.samsion.application.auth.service.AuthReIssueService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+	private final AuthReIssueService authReIssueService;
+
+	@GetMapping("/reissue")
+	public void reissue() {
+		authReIssueService.reissue();
+	}
+
+}


### PR DESCRIPTION
# Summary

---

* Ignored Path 상수 클래스 만들고 해당 클래스 안에 설정된 경로는 토큰 인증 과정을 진행하지 않음
* AuthController을 통해서 reissue Api 요청 받으면 refreshToken을 가지고 검증 후 accessToken 재발급
* sevlet, header, security 관련 유틸 클래스 추가
* cd workflow가 작동 안해서 수정


# Issue

---

#7 , 인증 경로 설정, 토큰 재발급은 로그인 과정이라고 생각해서 등록했어!

# References

---


