### PR TITLE
[feat] MyPet 조회/수정 API 추가 및 OAuth2 사용자 정보 저장 로직 리팩터링

### DIFF
--- a/src/main/java/com/kusitms/samsion/application/user/dto/request/MyPetUpdateRequest.java
+++ b/src/main/java/com/kusitms/samsion/application/user/dto/request/MyPetUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.kusitms.samsion.application.user.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MyPetUpdateRequest {
+
+	String petName;
+	String petImageUrl;
+	String description;
+
+	@Builder
+	public MyPetUpdateRequest(String petName, String petImageUrl, String description) {
+		this.petName = petName;
+		this.petImageUrl = petImageUrl;
+		this.description = description;
+	}
+
+}

--- a/src/main/java/com/kusitms/samsion/application/user/dto/request/UserSignUpRequest.java
+++ b/src/main/java/com/kusitms/samsion/application/user/dto/request/UserSignUpRequest.java
@@ -1,0 +1,15 @@
+package com.kusitms.samsion.application.user.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class UserSignUpRequest {
+
+	String email;
+	String nickname;
+
+	public UserSignUpRequest(String email, String nickname) {
+		this.email = email;
+		this.nickname = nickname;
+	}
+}

--- a/src/main/java/com/kusitms/samsion/application/user/dto/response/MyPetResponse.java
+++ b/src/main/java/com/kusitms/samsion/application/user/dto/response/MyPetResponse.java
@@ -1,0 +1,19 @@
+package com.kusitms.samsion.application.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MyPetResponse {
+
+	String petName;
+	String petImageUrl;
+	String description;
+
+	@Builder
+	public MyPetResponse(String petName, String petImageUrl, String description) {
+		this.petName = petName;
+		this.petImageUrl = petImageUrl;
+		this.description = description;
+	}
+}

--- a/src/main/java/com/kusitms/samsion/application/user/mapper/MyPetMapper.java
+++ b/src/main/java/com/kusitms/samsion/application/user/mapper/MyPetMapper.java
@@ -1,0 +1,28 @@
+package com.kusitms.samsion.application.user.mapper;
+
+import com.kusitms.samsion.application.user.dto.request.MyPetUpdateRequest;
+import com.kusitms.samsion.application.user.dto.response.MyPetResponse;
+import com.kusitms.samsion.common.annotation.Mapper;
+import com.kusitms.samsion.domain.user.entity.MyPet;
+import com.kusitms.samsion.domain.user.entity.User;
+
+@Mapper
+public class MyPetMapper {
+
+	public MyPetResponse getMyPetInfo(User user){
+		MyPet mypet = user.getMypet();
+		return MyPetResponse.builder()
+			.petName(mypet.getPetName())
+			.petImageUrl(mypet.getPetImageUrl())
+			.description(mypet.getDescription())
+			.build();
+	}
+
+	public MyPet updateMyPetInfo(MyPetUpdateRequest request){
+		return MyPet.builder()
+			.petName(request.getPetName())
+			.petImageUrl(request.getPetImageUrl())
+			.description(request.getDescription())
+			.build();
+	}
+}

--- a/src/main/java/com/kusitms/samsion/application/user/mapper/UserSignUpMapper.java
+++ b/src/main/java/com/kusitms/samsion/application/user/mapper/UserSignUpMapper.java
@@ -1,0 +1,18 @@
+package com.kusitms.samsion.application.user.mapper;
+
+import com.kusitms.samsion.application.user.dto.request.UserSignUpRequest;
+import com.kusitms.samsion.common.annotation.Mapper;
+import com.kusitms.samsion.domain.user.entity.User;
+
+@Mapper
+public class UserSignUpMapper {
+
+	public User toEntity(UserSignUpRequest request){
+		return User.builder()
+			.email(request.getEmail())
+			.nickname(request.getNickname())
+			.build();
+	}
+
+
+}

--- a/src/main/java/com/kusitms/samsion/application/user/service/MyPetInfoService.java
+++ b/src/main/java/com/kusitms/samsion/application/user/service/MyPetInfoService.java
@@ -1,0 +1,25 @@
+package com.kusitms.samsion.application.user.service;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kusitms.samsion.application.user.dto.response.MyPetResponse;
+import com.kusitms.samsion.application.user.mapper.MyPetMapper;
+import com.kusitms.samsion.common.annotation.ApplicationService;
+import com.kusitms.samsion.common.util.UserUtils;
+import com.kusitms.samsion.domain.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@ApplicationService
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPetInfoService {
+
+	private final UserUtils userUtils;
+	private final MyPetMapper myPetMapper;
+
+	public MyPetResponse getMyPetInfo(){
+		User user = userUtils.getUser();
+		return myPetMapper.getMyPetInfo(user);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/application/user/service/MyPetUpdateService.java
+++ b/src/main/java/com/kusitms/samsion/application/user/service/MyPetUpdateService.java
@@ -1,0 +1,30 @@
+package com.kusitms.samsion.application.user.service;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kusitms.samsion.application.user.dto.request.MyPetUpdateRequest;
+import com.kusitms.samsion.application.user.dto.response.MyPetResponse;
+import com.kusitms.samsion.application.user.mapper.MyPetMapper;
+import com.kusitms.samsion.common.annotation.ApplicationService;
+import com.kusitms.samsion.common.util.UserUtils;
+import com.kusitms.samsion.domain.user.entity.MyPet;
+import com.kusitms.samsion.domain.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class MyPetUpdateService {
+
+	private final UserUtils userUtils;
+	private final MyPetMapper myPetMapper;
+
+	@Transactional
+	public MyPetResponse updateMyPetInfo(MyPetUpdateRequest request){
+		User user = userUtils.getUser();
+		final MyPet myPet = myPetMapper.updateMyPetInfo(request);
+		user.updateMyPet(myPet);
+		return myPetMapper.getMyPetInfo(user);
+	}
+
+}

--- a/src/main/java/com/kusitms/samsion/application/user/service/UserSignUpService.java
+++ b/src/main/java/com/kusitms/samsion/application/user/service/UserSignUpService.java
@@ -1,0 +1,25 @@
+package com.kusitms.samsion.application.user.service;
+
+import org.springframework.context.event.EventListener;
+
+import com.kusitms.samsion.application.user.dto.request.UserSignUpRequest;
+import com.kusitms.samsion.application.user.mapper.UserSignUpMapper;
+import com.kusitms.samsion.common.annotation.ApplicationService;
+import com.kusitms.samsion.domain.user.entity.User;
+import com.kusitms.samsion.domain.user.service.UserSaveService;
+
+import lombok.RequiredArgsConstructor;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class UserSignUpService {
+
+	private final UserSignUpMapper userSignUpMapper;
+	private final UserSaveService userSaveService;
+
+	@EventListener
+	public void signUp(UserSignUpRequest request){
+		User user = userSignUpMapper.toEntity(request);
+		userSaveService.saveUser(user);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/common/annotation/Mapper.java
+++ b/src/main/java/com/kusitms/samsion/common/annotation/Mapper.java
@@ -1,0 +1,14 @@
+package com.kusitms.samsion.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.stereotype.Component;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Component
+public @interface Mapper {
+}

--- a/src/main/java/com/kusitms/samsion/common/config/CorsConfig.java
+++ b/src/main/java/com/kusitms/samsion/common/config/CorsConfig.java
@@ -1,0 +1,24 @@
+package com.kusitms.samsion.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsConfig {
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource(){
+		CorsConfiguration configuration = new CorsConfiguration();
+
+		configuration.addAllowedOrigin("*");
+		configuration.addAllowedMethod("*");
+		configuration.addAllowedHeader("*");
+		configuration.setAllowCredentials(true);
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
+	}
+}

--- a/src/main/java/com/kusitms/samsion/common/exception/BusinessException.java
+++ b/src/main/java/com/kusitms/samsion/common/exception/BusinessException.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public class BusinessException extends RuntimeException{
 
-	private Error error;
+	private final Error error;
 
 	public BusinessException(Error error) {
 		this.error = error;

--- a/src/main/java/com/kusitms/samsion/common/exception/Error.java
+++ b/src/main/java/com/kusitms/samsion/common/exception/Error.java
@@ -5,6 +5,10 @@ import lombok.Getter;
 @Getter
 public enum Error {
 
+	// 사용자
+	USER_NOT_FOUND("사용자를 찾을 수 없습니다.", 100),
+
+
 	// JWT
 	INVALID_TOKEN("잘못된 토큰 요청", 401),
 	EXPIRED_TOKEN("토큰 만료", 402);

--- a/src/main/java/com/kusitms/samsion/common/exception/dto/ErrorResponse.java
+++ b/src/main/java/com/kusitms/samsion/common/exception/dto/ErrorResponse.java
@@ -1,0 +1,19 @@
+package com.kusitms.samsion.common.exception.dto;
+
+import com.kusitms.samsion.common.exception.BusinessException;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+	private final int errorCode;
+
+
+	private ErrorResponse(int errorCode) {
+		this.errorCode = errorCode;
+	}
+
+	public static ErrorResponse from(BusinessException e){
+		return new ErrorResponse(e.getError().getErrorCode());
+	}
+}

--- a/src/main/java/com/kusitms/samsion/common/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/kusitms/samsion/common/security/jwt/JwtAuthenticationEntryPoint.java
@@ -11,10 +11,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kusitms.samsion.common.exception.dto.ErrorResponse;
 import com.kusitms.samsion.common.security.exception.JwtException;
 
-import lombok.Builder;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,26 +34,15 @@ public class JwtAuthenticationEntryPoint extends OncePerRequestFilter {
 			filterChain.doFilter(request, response);
 		} catch (JwtException e){
 			log.info("JwtException: {} {}",e.getError().getMessage(), e.getError().getErrorCode());
-			setErrorCode(response, e.getError().getErrorCode());
+			setErrorCode(response, e);
 		}
 	}
 
-	private void setErrorCode(HttpServletResponse response, int errorCode) throws IOException {
-		ErrorResponse errorResponse = ErrorResponse.builder()
-			.errorCode(errorCode)
-			.build();
+	private void setErrorCode(HttpServletResponse response, JwtException e) throws IOException {
+		ErrorResponse errorResponse = ErrorResponse.from(e);
 		response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 		response.setContentType("application/json");
 		response.setCharacterEncoding("UTF-8");
 		response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
-	}
-
-	@Getter
-	private static class ErrorResponse{
-		private final int errorCode;
-		@Builder
-		public ErrorResponse(int errorCode) {
-			this.errorCode = errorCode;
-		}
 	}
 }

--- a/src/main/java/com/kusitms/samsion/common/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kusitms/samsion/common/security/jwt/JwtAuthenticationFilter.java
@@ -56,9 +56,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		return true;
 	}
 
-	/**
-	 * TODO : header에서 유효성 검사 로직을 HeaderUtils로 분리할지 고민.
-	 */
 	private String validateAuthorizationHeaderAndGetToken(final String header) {
 		return SecurityUtils.validateHeaderAndGetToken(header);
 	}

--- a/src/main/java/com/kusitms/samsion/common/security/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/kusitms/samsion/common/security/jwt/JwtAuthenticationToken.java
@@ -7,7 +7,7 @@ import org.springframework.security.core.GrantedAuthority;
 
 public class JwtAuthenticationToken extends AbstractAuthenticationToken {
 
-	private String email;
+	private final String email;
 
 	public JwtAuthenticationToken(Collection<? extends GrantedAuthority> authorities, String email) {
 		super(authorities);

--- a/src/main/java/com/kusitms/samsion/common/security/jwt/JwtProvider.java
+++ b/src/main/java/com/kusitms/samsion/common/security/jwt/JwtProvider.java
@@ -5,6 +5,7 @@ import static com.kusitms.samsion.common.consts.ApplicationConst.*;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.redis.core.RedisTemplate;
@@ -65,10 +66,6 @@ public class JwtProvider {
 			TimeUnit.MILLISECONDS);
 	}
 
-	private String getRefreshToken(String email) {
-		return redisTemplate.opsForValue().get(email);
-	}
-
 	private JwtBuilder buildToken(Date now) {
 		final Key key = getSecretKey();
 		return Jwts.builder()
@@ -123,10 +120,14 @@ public class JwtProvider {
 		validateToken(refreshToken);
 		final String email = extractEmail(refreshToken);
 		final String storedRefreshToken = getRefreshToken(email);
-		if(!storedRefreshToken.equals(refreshToken)){
+		if(!Objects.equals(refreshToken, storedRefreshToken)){
 			throw new InvalidTokenException(Error.INVALID_TOKEN);
 		}
 		return email;
+	}
+
+	private String getRefreshToken(String email) {
+		return redisTemplate.opsForValue().get(email);
 	}
 
 

--- a/src/main/java/com/kusitms/samsion/common/security/oauth/OAuth2Attributes.java
+++ b/src/main/java/com/kusitms/samsion/common/security/oauth/OAuth2Attributes.java
@@ -16,16 +16,13 @@ public class OAuth2Attributes {
 	private String nameAttributeKey;
 	private String name;
 	private String email;
-	private String imageUrl;
 
 	@Builder
-	public OAuth2Attributes(Map<String, Object> attributes, String nameAttributeKey, String name, String email,
-		String imageUrl) {
+	public OAuth2Attributes(Map<String, Object> attributes, String nameAttributeKey, String name, String email) {
 		this.attributes = attributes;
 		this.nameAttributeKey = nameAttributeKey;
 		this.name = name;
 		this.email = email;
-		this.imageUrl = imageUrl;
 	}
 
 	public OAuth2Attributes() {
@@ -41,15 +38,16 @@ public class OAuth2Attributes {
 			.nameAttributeKey(userNameAttributeName)
 			.name((String) attributes.get("name"))
 			.email((String) attributes.get("email"))
-			.imageUrl((String) attributes.get("picture"))
 			.build();
 	}
 
+	/**
+	 * mapper class로 분리
+	 */
 	public User toEntity() {
 		return User.builder()
 			.nickname(name)
 			.email(email)
-			.imageUrl(imageUrl)
 			.build();
 	}
 }

--- a/src/main/java/com/kusitms/samsion/common/util/SecurityUtils.java
+++ b/src/main/java/com/kusitms/samsion/common/util/SecurityUtils.java
@@ -2,11 +2,13 @@ package com.kusitms.samsion.common.util;
 
 import java.util.Optional;
 
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 
 import com.kusitms.samsion.common.consts.ApplicationConst;
 import com.kusitms.samsion.common.exception.Error;
 import com.kusitms.samsion.common.security.exception.TokenNotFoundException;
+import com.kusitms.samsion.common.security.jwt.JwtAuthenticationToken;
 
 import lombok.NoArgsConstructor;
 
@@ -19,6 +21,14 @@ public class SecurityUtils {
 			.filter(StringUtils::hasText)
 			.map(header -> header.replace(ApplicationConst.JWT_AUTHORIZATION_TYPE, ""))
 			.orElseThrow(() -> new TokenNotFoundException(Error.INVALID_TOKEN));
+	}
+
+	public static String getUserEmail(){
+		return (String)getAuthentication().getPrincipal();
+	}
+
+	private static JwtAuthenticationToken getAuthentication(){
+		return (JwtAuthenticationToken)SecurityContextHolder.getContext().getAuthentication();
 	}
 
 }

--- a/src/main/java/com/kusitms/samsion/common/util/UserUtils.java
+++ b/src/main/java/com/kusitms/samsion/common/util/UserUtils.java
@@ -1,0 +1,20 @@
+package com.kusitms.samsion.common.util;
+
+import org.springframework.stereotype.Component;
+
+import com.kusitms.samsion.domain.user.entity.User;
+import com.kusitms.samsion.domain.user.service.UserGetService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserUtils {
+
+	private final UserGetService userGetService;
+
+	public User getUser(){
+		final String userEmail = SecurityUtils.getUserEmail();
+		return userGetService.getUserByEmail(userEmail);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/user/entity/MyPet.java
+++ b/src/main/java/com/kusitms/samsion/domain/user/entity/MyPet.java
@@ -1,0 +1,41 @@
+package com.kusitms.samsion.domain.user.entity;
+
+import javax.persistence.Embeddable;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyPet {
+
+	String petName;
+	String petImageUrl;
+	String description;
+
+	@Builder
+	public MyPet(String petName, String petImageUrl, String description) {
+		this.petName = petName;
+		this.petImageUrl = petImageUrl;
+		this.description = description;
+	}
+
+	public void updateInfo(MyPet myPet){
+		this.petName = myPet.getPetName();
+		this.petImageUrl = myPet.getPetImageUrl();
+		this.description = myPet.getDescription();
+	}
+
+	public static MyPet defaultValue(){
+		return MyPet.builder()
+				.petName("익명이")
+				.petImageUrl("")
+				.description("익명이 설명이에요!")
+				.build();
+	}
+
+
+}

--- a/src/main/java/com/kusitms/samsion/domain/user/entity/User.java
+++ b/src/main/java/com/kusitms/samsion/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.kusitms.samsion.domain.user.entity;
 
 import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -24,21 +25,23 @@ public class User extends BaseEntity {
 
 	private String nickname;
 	private String email;
-	private String imageUrl;
+
+	@Embedded
+	private MyPet mypet;
 
 
 	@Builder
-	public User(String nickname, String email, String imageUrl) {
+	public User(String nickname, String email) {
 		this.nickname = nickname;
 		this.email = email;
-		this.imageUrl = imageUrl;
+		this.mypet = MyPet.defaultValue();
 	}
 
-	public User update(String nickname, String imageUrl) {
-		this.nickname = nickname;
-		this.imageUrl = imageUrl;
-		return this;
+	public void updateMyPet(MyPet mypet){
+		this.mypet.updateInfo(mypet);
 	}
+
+
 
 	@Override
 	public String toString() {
@@ -46,7 +49,6 @@ public class User extends BaseEntity {
 			"id=" + id +
 			", nickname='" + nickname + '\'' +
 			", email='" + email + '\'' +
-			", imageUrl='" + imageUrl +
 			'}';
 	}
 }

--- a/src/main/java/com/kusitms/samsion/domain/user/exception/UserException.java
+++ b/src/main/java/com/kusitms/samsion/domain/user/exception/UserException.java
@@ -1,0 +1,11 @@
+package com.kusitms.samsion.domain.user.exception;
+
+import com.kusitms.samsion.common.exception.BusinessException;
+import com.kusitms.samsion.common.exception.Error;
+
+public class UserException extends BusinessException {
+
+	public UserException(Error error) {
+		super(error);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/kusitms/samsion/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package com.kusitms.samsion.domain.user.exception;
+
+import com.kusitms.samsion.common.exception.Error;
+
+public class UserNotFoundException extends UserException{
+	public UserNotFoundException(Error error) {
+		super(error);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kusitms/samsion/domain/user/repository/UserRepository.java
@@ -9,4 +9,6 @@ import com.kusitms.samsion.domain.user.entity.User;
 public interface UserRepository extends JpaRepository<User, Long> {
 
 	Optional<User> findByEmail(String email);
+
+	boolean existsByEmail(String email);
 }

--- a/src/main/java/com/kusitms/samsion/domain/user/service/UserGetService.java
+++ b/src/main/java/com/kusitms/samsion/domain/user/service/UserGetService.java
@@ -1,0 +1,24 @@
+package com.kusitms.samsion.domain.user.service;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kusitms.samsion.common.annotation.DomainService;
+import com.kusitms.samsion.common.exception.Error;
+import com.kusitms.samsion.domain.user.entity.User;
+import com.kusitms.samsion.domain.user.exception.UserNotFoundException;
+import com.kusitms.samsion.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class UserGetService {
+
+	private final UserRepository userRepository;
+
+	@Transactional(readOnly = true)
+	public User getUserByEmail(String email) {
+		return userRepository.findByEmail(email)
+			.orElseThrow(() -> new UserNotFoundException(Error.USER_NOT_FOUND));
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/user/service/UserSaveService.java
+++ b/src/main/java/com/kusitms/samsion/domain/user/service/UserSaveService.java
@@ -1,0 +1,24 @@
+package com.kusitms.samsion.domain.user.service;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kusitms.samsion.common.annotation.DomainService;
+import com.kusitms.samsion.domain.user.entity.User;
+import com.kusitms.samsion.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class UserSaveService {
+
+	private final UserRepository userRepository;
+
+	@Transactional
+	public void saveUser(User user) {
+		if(!userRepository.existsByEmail(user.getEmail())){
+			userRepository.save(user);
+		}
+	}
+
+}

--- a/src/main/java/com/kusitms/samsion/presentation/user/UserController.java
+++ b/src/main/java/com/kusitms/samsion/presentation/user/UserController.java
@@ -1,0 +1,34 @@
+package com.kusitms.samsion.presentation.user;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kusitms.samsion.application.user.dto.request.MyPetUpdateRequest;
+import com.kusitms.samsion.application.user.dto.response.MyPetResponse;
+import com.kusitms.samsion.application.user.service.MyPetInfoService;
+import com.kusitms.samsion.application.user.service.MyPetUpdateService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserController {
+
+	private final MyPetInfoService myPetInfoService;
+	private final MyPetUpdateService myPetUpdateService;
+
+	@GetMapping("/mypet")
+	public MyPetResponse getMyPetInfo(){
+		return myPetInfoService.getMyPetInfo();
+	}
+
+	@PostMapping("/mypet")
+	public  MyPetResponse profileUpdate(@RequestBody MyPetUpdateRequest request){
+		return myPetUpdateService.updateMyPetInfo(request);
+	}
+
+}


### PR DESCRIPTION
# Summary

---

* MyPet 값 객체를 추가
* MyPet 조회/수정 로직 추가
* 토큰 정보를 통해 현재 요청한 사용자 정보 가져오는 util 클래스 추가
* OAuth2에서 사용자가 인증이 완료되면 해당 정보를 가지고 이벤트를 통한 사용자 저장로직 구현
* cors 설정 추가

# Issue

---

#8 #22 


# References

---


