### PR TITLE
[feat] 댓글 service 테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,10 @@ asciidoctor {
     dependsOn test
     configurations 'asciidoctorExtensions'
     inputs.dir snippetsDir
+
+    sources {
+        include('src/docs/asciidoc/*.adoc')
+    }
 }
 
 asciidoctor.doFirst {
@@ -94,6 +98,6 @@ task copyDocument(type: Copy) {
     into file("src/main/resources/static/docs")
 }
 
-build {
+bootJar {
     dependsOn copyDocument
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -7,7 +7,9 @@
 :sectlinks:
 
 include::User-API.adoc[]
+
 include::Question-API.adoc[]
+
 include::Empathy-API.adoc[]
 
 include::Comment-API.adoc[]

--- a/src/main/java/com/kusitms/samsion/application/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/kusitms/samsion/application/comment/dto/request/CommentUpdateRequest.java
@@ -6,11 +6,11 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class CommentCreateRequest {
+public class CommentUpdateRequest {
     private String description;
 
     @Builder
-    public CommentCreateRequest(String description) {
+    public CommentUpdateRequest(String description) {
         this.description = description;
     }
 }

--- a/src/main/java/com/kusitms/samsion/application/comment/mapper/CommentMapper.java
+++ b/src/main/java/com/kusitms/samsion/application/comment/mapper/CommentMapper.java
@@ -25,7 +25,6 @@ public class CommentMapper {
                 .writer(user)
                 .parent(parent)
                 .build();
-        comment.setParent(parent);
         return comment;
     }
 

--- a/src/main/java/com/kusitms/samsion/application/comment/service/CommentCreateService.java
+++ b/src/main/java/com/kusitms/samsion/application/comment/service/CommentCreateService.java
@@ -1,5 +1,6 @@
 package com.kusitms.samsion.application.comment.service;
 
+import com.kusitms.samsion.application.comment.dto.request.CommentCreateRequest;
 import com.kusitms.samsion.application.comment.dto.response.CommentInfoResponse;
 import com.kusitms.samsion.application.comment.mapper.CommentMapper;
 import com.kusitms.samsion.common.annotation.ApplicationService;
@@ -22,21 +23,21 @@ public class CommentCreateService {
     private final CommentQueryService commentQueryService;
 
     @Transactional
-    public CommentInfoResponse createComment(Long albumId, String description){
+    public CommentInfoResponse createComment(Long albumId, CommentCreateRequest commentCreateRequest){
         final User user = userUtils.getUser();
         final Album album = albumQueryService.getAlbumById(albumId);
-        final Comment comment = CommentMapper.mapToCommentWithUserAndAlbum(description, album, user);
+        final Comment comment = CommentMapper.mapToCommentWithUserAndAlbum(commentCreateRequest.getDescription(), album, user);
 
         commentSaveService.saveComment(comment);
         return CommentMapper.mapToCommentInfoResponse(comment);
     }
 
     @Transactional
-    public CommentInfoResponse createReComment(Long albumId, Long commentId, String description){
+    public CommentInfoResponse createReComment(Long albumId, Long commentId, CommentCreateRequest commentCreateRequest){
         final User user = userUtils.getUser();
         final Album album = albumQueryService.getAlbumById(albumId);
         final Comment parent = commentQueryService.getCommentById(commentId);
-        final Comment comment = CommentMapper.mapToCommentWithUserAndAlbumAndParent(description, album, user, parent);
+        final Comment comment = CommentMapper.mapToCommentWithUserAndAlbumAndParent(commentCreateRequest.getDescription(), album, user, parent);
 
         commentSaveService.saveComment(comment);
         return CommentMapper.mapToCommentInfoResponse(comment);

--- a/src/main/java/com/kusitms/samsion/application/comment/service/CommentUpdateService.java
+++ b/src/main/java/com/kusitms/samsion/application/comment/service/CommentUpdateService.java
@@ -1,5 +1,6 @@
 package com.kusitms.samsion.application.comment.service;
 
+import com.kusitms.samsion.application.comment.dto.request.CommentUpdateRequest;
 import com.kusitms.samsion.application.comment.dto.response.CommentInfoResponse;
 import com.kusitms.samsion.application.comment.mapper.CommentMapper;
 import com.kusitms.samsion.common.annotation.ApplicationService;
@@ -11,9 +12,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CommentUpdateService {
     private final CommentQueryService commentQueryService;
-    public CommentInfoResponse updateComment(Long commentId, String description) {
+    public CommentInfoResponse updateComment(Long commentId, CommentUpdateRequest commentUpdateRequest) {
         final Comment comment = commentQueryService.getCommentById(commentId);
-        comment.updateDescription(description);
+        comment.updateDescription(commentUpdateRequest.getDescription());
         return CommentMapper.mapToCommentInfoResponse(comment);
     }
 }

--- a/src/main/java/com/kusitms/samsion/domain/comment/entity/Comment.java
+++ b/src/main/java/com/kusitms/samsion/domain/comment/entity/Comment.java
@@ -39,12 +39,6 @@ public class Comment extends BaseEntity {
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
     private List<Comment> childList = new ArrayList<>();
 
-    //연관관계 편의 메서드
-    public void setParent(Comment parent){
-        this.parent = parent;
-        parent.addChild(this);
-    }
-
     public void addChild(Comment child){
         childList.add(child);
     }
@@ -61,6 +55,8 @@ public class Comment extends BaseEntity {
         this.writer = writer;
         this.parent = parent;
         album.addComment(this);
+        if(parent != null)
+            parent.addChild(this);
     }
 
 

--- a/src/main/java/com/kusitms/samsion/presentation/comment/CommentController.java
+++ b/src/main/java/com/kusitms/samsion/presentation/comment/CommentController.java
@@ -1,6 +1,7 @@
 package com.kusitms.samsion.presentation.comment;
 
 import com.kusitms.samsion.application.comment.dto.request.CommentCreateRequest;
+import com.kusitms.samsion.application.comment.dto.request.CommentUpdateRequest;
 import com.kusitms.samsion.application.comment.dto.response.CommentInfoResponse;
 import com.kusitms.samsion.application.comment.service.CommentCreateService;
 import com.kusitms.samsion.application.comment.service.CommentUpdateService;
@@ -17,17 +18,17 @@ public class CommentController {
 
     @PostMapping("/{albumId}/comment")
     public CommentInfoResponse createComment(@PathVariable Long albumId, CommentCreateRequest commentCreateRequest) {
-        return commentCreateService.createComment(albumId, commentCreateRequest.getDescription());
+        return commentCreateService.createComment(albumId, commentCreateRequest);
     }
 
     @PostMapping("/{albumId}/comment/{commentId}")
     public CommentInfoResponse createReComment(@PathVariable Long albumId, @PathVariable Long commentId,
                                                CommentCreateRequest commentCreateRequest) {
-        return commentCreateService.createReComment(albumId, commentId, commentCreateRequest.getDescription());
+        return commentCreateService.createReComment(albumId, commentId, commentCreateRequest);
     }
 
     @PutMapping("/comment/{commentId}")
-    public CommentInfoResponse update(@PathVariable Long commentId, CommentCreateRequest commentCreateRequest){
-        return commentUpdateService.updateComment(commentId, commentCreateRequest.getDescription());
+    public CommentInfoResponse update(@PathVariable Long commentId, CommentUpdateRequest commentUpdateRequest){
+        return commentUpdateService.updateComment(commentId, commentUpdateRequest);
     }
 }

--- a/src/main/resources/static/docs/Comment-API.html
+++ b/src/main/resources/static/docs/Comment-API.html
@@ -864,7 +864,7 @@ Content-Length: 89
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-05-11 01:21:57 +0900
+Last updated 2023-05-12 01:36:09 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/Comment-API.html
+++ b/src/main/resources/static/docs/Comment-API.html
@@ -452,11 +452,11 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /album/1/comment HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: access token
-Content-Length: 30
+Content-Length: 48
 Host: localhost:8080
 
 {
-  "description" : "test"
+  "description" : "testCommentDescription"
 }</code></pre>
 </div>
 </div>
@@ -534,12 +534,12 @@ Host: localhost:8080
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 89
+Content-Length: 115
 
 {
-  "description" : "test",
+  "description" : "testCommentDescription",
   "writer" : "test",
-  "writerProfileImageUrl" : "test"
+  "writerProfileImageUrl" : "testImageUrl"
 }</code></pre>
 </div>
 </div>
@@ -589,11 +589,11 @@ Content-Length: 89
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /album/1/comment/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: access token
-Content-Length: 30
+Content-Length: 53
 Host: localhost:8080
 
 {
-  "description" : "test"
+  "description" : "testChildCommentDescription"
 }</code></pre>
 </div>
 </div>
@@ -675,12 +675,12 @@ Host: localhost:8080
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 89
+Content-Length: 120
 
 {
-  "description" : "test",
+  "description" : "testChildCommentDescription",
   "writer" : "test",
-  "writerProfileImageUrl" : "test"
+  "writerProfileImageUrl" : "testImageUrl"
 }</code></pre>
 </div>
 </div>
@@ -730,11 +730,11 @@ Content-Length: 89
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /album/comment/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: access token
-Content-Length: 30
+Content-Length: 54
 Host: localhost:8080
 
 {
-  "description" : "test"
+  "description" : "testUpdateCommentDescription"
 }</code></pre>
 </div>
 </div>
@@ -812,12 +812,12 @@ Host: localhost:8080
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 89
+Content-Length: 121
 
 {
-  "description" : "test",
+  "description" : "testUpdateCommentDescription",
   "writer" : "test",
-  "writerProfileImageUrl" : "test"
+  "writerProfileImageUrl" : "testImageUrl"
 }</code></pre>
 </div>
 </div>

--- a/src/main/resources/static/docs/Empathy-API.html
+++ b/src/main/resources/static/docs/Empathy-API.html
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.10">
-<title>Samsion API Doc</title>
+<title>Empathy-API</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
@@ -435,25 +435,89 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 #footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
 @media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
 </style>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="book">
+<body class="article">
 <div id="header">
-<h1>Samsion API Doc</h1>
-<div class="details">
-<span id="revnumber">version 0.0.1-SNAPSHOT</span>
-</div>
 </div>
 <div id="content">
-<div id="preamble">
+<div class="sect1">
+<h2 id="Empathy-API">Empathy-API</h2>
 <div class="sectionbody">
-<div class="paragraph">
-<p>Unresolved directive in index.adoc - include::User-API.adoc[]
-Unresolved directive in index.adoc - include::Question-API.adoc[]
-Unresolved directive in index.adoc - include::Empathy-API.adoc[]</p>
+<div class="sect2">
+<h3 id="Empathy-공감-생성">Empathy 공감 생성</h3>
+<div class="sect3">
+<h4 id="Empathy-공감-생성_http_request">HTTP request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /album/1/empathy HTTP/1.1
+Authorization: access token
+Host: localhost:8080</code></pre>
 </div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="Empathy-공감-생성_request_headers">Request headers</h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">access token</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="Empathy-공감-생성_path_parameters">Path parameters</h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /album/{albumId}/empathy</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>albumId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">앨범 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="Empathy-공감-생성_request_fields">Request fields</h4>
 <div class="paragraph">
-<p>Unresolved directive in index.adoc - include::Comment-API.adoc[]</p>
+<p>Snippet request-fields not found for operation::empathy-controller-test/접속중인_앨범에서_공감_get_요청이_정상적으로_들어온다</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="Empathy-공감-생성_http_response">HTTP response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="Empathy-공감-생성_response_fields">Response fields</h4>
+<div class="paragraph">
+<p>Snippet response-fields not found for operation::empathy-controller-test/접속중인_앨범에서_공감_get_요청이_정상적으로_들어온다</p>
+</div>
+</div>
 </div>
 </div>
 </div>
@@ -464,8 +528,5 @@ Version 0.0.1-SNAPSHOT<br>
 Last updated 2023-05-12 01:36:09 +0900
 </div>
 </div>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/highlight.min.js"></script>
-<script>hljs.initHighlighting()</script>
 </body>
 </html>

--- a/src/main/resources/static/docs/Question-API.html
+++ b/src/main/resources/static/docs/Question-API.html
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.10">
-<title>Samsion API Doc</title>
+<title>Question API</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
@@ -435,25 +435,348 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 #footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
 @media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
 </style>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="book">
+<body class="article">
 <div id="header">
-<h1>Samsion API Doc</h1>
-<div class="details">
-<span id="revnumber">version 0.0.1-SNAPSHOT</span>
-</div>
 </div>
 <div id="content">
-<div id="preamble">
+<div class="sect1">
+<h2 id="Question-API">Question API</h2>
 <div class="sectionbody">
-<div class="paragraph">
-<p>Unresolved directive in index.adoc - include::User-API.adoc[]
-Unresolved directive in index.adoc - include::Question-API.adoc[]
-Unresolved directive in index.adoc - include::Empathy-API.adoc[]</p>
+
 </div>
+</div>
+<div class="sect1">
+<h2 id="Question-모든-조회-조회">Question 모든 질문 조회</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="Question-모든-조회-조회_http_request">HTTP request</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /question?page=0&amp;size=10 HTTP/1.1
+Authorization: Bearer testAccessToken
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="Question-모든-조회-조회_request_headers">Request headers</h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">access token</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="Question-모든-조회-조회_path_parameters">Path parameters</h3>
 <div class="paragraph">
-<p>Unresolved directive in index.adoc - include::Comment-API.adoc[]</p>
+<p>Snippet path-parameters not found for operation::question-controller-test/모든_질문을_조회한다</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="Question-모든-조회-조회_request_fields">Request fields</h3>
+<div class="paragraph">
+<p>Snippet request-fields not found for operation::question-controller-test/모든_질문을_조회한다</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="Question-모든-조회-조회_http_response">HTTP response</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 253
+
+{
+  "content" : [ {
+    "questionId" : 1,
+    "questionTitle" : "testQuestionTitle",
+    "answerDescription" : "testAnswerDescription"
+  } ],
+  "pageNumber" : 0,
+  "pageSize" : 20,
+  "totalElements" : 1,
+  "totalPages" : 1,
+  "last" : false
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="Question-모든-조회-조회_response_fields">Response fields</h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].questionId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">질문 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].questionTitle</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">질문 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].answerDescription</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">답변 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>pageNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>pageSize</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 사이즈</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>totalElements</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전체 요소 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>totalPages</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전체 페이지 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>last</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 페이지 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="Question-질문-답변-작성">Question 질문 답변 작성</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="Question-질문-답변-작성_http_request">HTTP request</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /question/1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer testAccessToken
+Content-Length: 53
+Host: localhost:8080
+
+{
+  "answerDescription" : "testAnswerDescription"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="Question-질문-답변-작성_request_headers">Request headers</h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">access token</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="Question-질문-답변-작성_path_parameters">Path parameters</h3>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /question/{questionId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>questionId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">질문 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="Question-질문-답변-작성_request_fields">Request fields</h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>answerDescription</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">답변 내용</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="Question-질문-답변-작성_http_response">HTTP response</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="Question-질문-답변-작성_response_fields">Response fields</h3>
+<div class="paragraph">
+<p>Snippet response-fields not found for operation::question-controller-test/질문에_대한_답변을_작성한다</p>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="Question-질문-답변-수정">Question 질문 답변 수정</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="Question-질문-답변-수정_http_request">HTTP request</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /question/1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer testAccessToken
+Content-Length: 53
+Host: localhost:8080
+
+{
+  "answerDescription" : "testAnswerDescription"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="Question-질문-답변-수정_request_headers">Request headers</h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">access token</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="Question-질문-답변-수정_path_parameters">Path parameters</h3>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /question/{questionId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>questionId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">질문 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="Question-질문-답변-수정_request_fields">Request fields</h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>answerDescription</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">답변 내용</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="Question-질문-답변-수정_http_response">HTTP response</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="Question-질문-답변-수정_response_fields">Response fields</h3>
+<div class="paragraph">
+<p>Snippet response-fields not found for operation::question-controller-test/질문을_수정한다</p>
+</div>
 </div>
 </div>
 </div>
@@ -464,8 +787,5 @@ Version 0.0.1-SNAPSHOT<br>
 Last updated 2023-05-12 01:36:09 +0900
 </div>
 </div>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/highlight.min.js"></script>
-<script>hljs.initHighlighting()</script>
 </body>
 </html>

--- a/src/main/resources/static/docs/User-API.html
+++ b/src/main/resources/static/docs/User-API.html
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.10">
-<title>Samsion API Doc</title>
+<title>User-API</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
@@ -435,25 +435,226 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 #footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
 @media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
 </style>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="book">
+<body class="article">
 <div id="header">
-<h1>Samsion API Doc</h1>
-<div class="details">
-<span id="revnumber">version 0.0.1-SNAPSHOT</span>
-</div>
 </div>
 <div id="content">
-<div id="preamble">
+<div class="sect1">
+<h2 id="User-API">User-API</h2>
 <div class="sectionbody">
-<div class="paragraph">
-<p>Unresolved directive in index.adoc - include::User-API.adoc[]
-Unresolved directive in index.adoc - include::Question-API.adoc[]
-Unresolved directive in index.adoc - include::Empathy-API.adoc[]</p>
+
 </div>
+</div>
+<div class="sect1">
+<h2 id="User-mypet-정보-조회">User mypet 정보 조회</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="User-mypet-정보-조회_http_request">HTTP request</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /user/mypet HTTP/1.1
+Authorization: access token
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="User-mypet-정보-조회_request_headers">Request headers</h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">access token</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="User-mypet-정보-조회_path_parameters">Path parameters</h3>
 <div class="paragraph">
-<p>Unresolved directive in index.adoc - include::Comment-API.adoc[]</p>
+<p>Snippet path-parameters not found for operation::user-controller-test/접속한_사용자의_mypet_조회</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="User-mypet-정보-조회_request_fields">Request fields</h3>
+<div class="paragraph">
+<p>Snippet request-fields not found for operation::user-controller-test/접속한_사용자의_mypet_조회</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="User-mypet-정보-조회_http_response">HTTP response</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 102
+
+{
+  "petName" : "testPet",
+  "petImageUrl" : "testImageUrl",
+  "description" : "testDescription"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="User-mypet-정보-조회_response_fields">Response fields</h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>petName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">반려동물 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>petImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">반려동물 이미지 URL</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>description</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">반려동물 설명</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="User-mypet-정보-수정">User mypet 정보 수정</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="User-mypet-정보-수정_http_request">HTTP request</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /user/mypet HTTP/1.1
+Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Authorization: access token
+Host: localhost:8080
+
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=petName
+
+testUpdatePet
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=description
+
+testUpdateDescription
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=file; filename=test.png
+Content-Type: image/png
+
+test
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="User-mypet-정보-수정_request_headers">Request headers</h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">access token</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="User-mypet-정보-수정_path_parameters">Path parameters</h3>
+<div class="paragraph">
+<p>Snippet path-parameters not found for operation::user-controller-test/접속한_사용자의_mypet_수정</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="User-mypet-정보-수정_request_fields">Request fields</h3>
+<div class="paragraph">
+<p>Snippet request-fields not found for operation::user-controller-test/접속한_사용자의_mypet_수정</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="User-mypet-정보-수정_http_response">HTTP response</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 102
+
+{
+  "petName" : "testPet",
+  "petImageUrl" : "testImageUrl",
+  "description" : "testDescription"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="User-mypet-정보-수정_response_fields">Response fields</h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>petName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">반려동물 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>petImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">반려동물 이미지 URL</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>description</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">반려동물 설명</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 </div>
 </div>
@@ -464,8 +665,5 @@ Version 0.0.1-SNAPSHOT<br>
 Last updated 2023-05-12 01:36:09 +0900
 </div>
 </div>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/highlight.min.js"></script>
-<script>hljs.initHighlighting()</script>
 </body>
 </html>

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -461,7 +461,7 @@ Unresolved directive in index.adoc - include::Empathy-API.adoc[]</p>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-05-12 01:36:09 +0900
+Last updated 2023-05-12 02:11:53 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/java/com/kusitms/samsion/application/comment/service/CommentCreateServiceTest.java
+++ b/src/test/java/com/kusitms/samsion/application/comment/service/CommentCreateServiceTest.java
@@ -1,0 +1,94 @@
+package com.kusitms.samsion.application.comment.service;
+
+import com.kusitms.samsion.application.comment.dto.request.CommentCreateRequest;
+import com.kusitms.samsion.application.comment.dto.response.CommentInfoResponse;
+import com.kusitms.samsion.common.consts.TestConst;
+import com.kusitms.samsion.common.util.AlbumTestUtils;
+import com.kusitms.samsion.common.util.CommentTestUtils;
+import com.kusitms.samsion.common.util.UserTestUtils;
+import com.kusitms.samsion.common.util.UserUtils;
+import com.kusitms.samsion.domain.album.entity.Album;
+import com.kusitms.samsion.domain.album.service.AlbumQueryService;
+import com.kusitms.samsion.domain.comment.entity.Comment;
+import com.kusitms.samsion.domain.comment.service.CommentQueryService;
+import com.kusitms.samsion.domain.comment.service.CommentSaveService;
+import com.kusitms.samsion.domain.user.entity.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CommentCreateService 테스트")
+public class CommentCreateServiceTest {
+
+    @Mock
+    private UserUtils userUtils;
+
+    @Mock
+    private AlbumQueryService albumQueryService;
+
+    @Mock
+    private CommentSaveService commentSaveService;
+
+    @Mock
+    private CommentQueryService commentQueryService;
+
+    private CommentCreateService commentCreateService;
+
+    @BeforeEach
+    void setUp() {
+        commentCreateService = new CommentCreateService(userUtils, albumQueryService, commentSaveService, commentQueryService);
+    }
+
+    @Test
+    public void 댓글을_생성한다() {
+        // given
+        User mockUser = UserTestUtils.getMockUser();
+        Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+        CommentCreateRequest commentCreateRequest = new CommentCreateRequest(TestConst.TEST_COMMENT_DESCRIPTION);
+
+        given(userUtils.getUser()).willReturn(mockUser);
+        given(albumQueryService.getAlbumById(mockAlbum.getId())).willReturn(mockAlbum);
+
+        // when
+        CommentInfoResponse commentInfoResponse = commentCreateService.createComment(mockAlbum.getId(), commentCreateRequest);
+
+        //then
+        then(commentSaveService).should(times(1)).saveComment(any(Comment.class));
+        Assertions.assertThat(commentInfoResponse).isNotNull();
+        Assertions.assertThat(commentInfoResponse.getWriterProfileImageUrl()).isEqualTo(mockUser.getMypet().getPetImageUrl());
+        Assertions.assertThat(commentInfoResponse.getDescription()).isEqualTo(commentCreateRequest.getDescription());
+        Assertions.assertThat(commentInfoResponse.getWriter()).isEqualTo(mockUser.getNickname());
+    }
+
+    @Test
+    public void 대댓글을_생성한다() {
+        //given
+        User mockUser = UserTestUtils.getMockUser();
+        Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+        Comment mockParentComment = CommentTestUtils.getMockComment(mockUser, mockAlbum);
+        CommentCreateRequest commentCreateRequest = new CommentCreateRequest(TestConst.TEST_CHILD_COMMENT_DESCRIPTION);
+        given(userUtils.getUser()).willReturn(mockUser);
+        given(albumQueryService.getAlbumById(mockAlbum.getId())).willReturn(mockAlbum);
+        given(commentQueryService.getCommentById(mockParentComment.getId())).willReturn(mockParentComment);
+        //when
+        CommentInfoResponse commentInfoResponse = commentCreateService.createReComment(mockAlbum.getId(), mockParentComment.getId(), commentCreateRequest);
+
+        //then
+        then(commentSaveService).should(times(1)).saveComment(any(Comment.class));
+        Assertions.assertThat(commentInfoResponse).isNotNull();
+        Assertions.assertThat(commentInfoResponse.getWriterProfileImageUrl()).isEqualTo(mockUser.getMypet().getPetImageUrl());
+        Assertions.assertThat(commentInfoResponse.getDescription()).isEqualTo(commentCreateRequest.getDescription());
+        Assertions.assertThat(commentInfoResponse.getWriter()).isEqualTo(mockUser.getNickname());
+    }
+
+}

--- a/src/test/java/com/kusitms/samsion/application/comment/service/CommentUpdateServiceTest.java
+++ b/src/test/java/com/kusitms/samsion/application/comment/service/CommentUpdateServiceTest.java
@@ -1,0 +1,54 @@
+package com.kusitms.samsion.application.comment.service;
+
+import com.kusitms.samsion.application.comment.dto.request.CommentUpdateRequest;
+import com.kusitms.samsion.application.comment.dto.response.CommentInfoResponse;
+import com.kusitms.samsion.common.consts.TestConst;
+import com.kusitms.samsion.common.util.AlbumTestUtils;
+import com.kusitms.samsion.common.util.CommentTestUtils;
+import com.kusitms.samsion.common.util.UserTestUtils;
+import com.kusitms.samsion.domain.album.entity.Album;
+import com.kusitms.samsion.domain.comment.entity.Comment;
+import com.kusitms.samsion.domain.comment.service.CommentQueryService;
+import com.kusitms.samsion.domain.user.entity.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CommentUpdateService 테스트")
+public class CommentUpdateServiceTest {
+    @Mock
+    private CommentQueryService commentQueryService;
+    private CommentUpdateService commentUpdateService;
+
+    @BeforeEach
+    public void setUp() {
+        commentUpdateService = new CommentUpdateService(commentQueryService);
+    }
+
+    @Test
+    public void 댓글을_수정한다() {
+        //given
+        User mockUser = UserTestUtils.getMockUser();
+        Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+        Comment mockComment = CommentTestUtils.getMockComment(mockUser, mockAlbum);
+        CommentUpdateRequest commentUpdateRequest = new CommentUpdateRequest(TestConst.TEST_UPDATE_COMMENT_DESCRIPTION);
+        given(commentQueryService.getCommentById(mockComment.getId())).willReturn(mockComment);
+
+        //when
+        CommentInfoResponse commentInfoResponse = commentUpdateService.updateComment(mockComment.getId(), commentUpdateRequest);
+
+        //then
+        Assertions.assertThat(commentInfoResponse).isNotNull();
+        Assertions.assertThat(commentInfoResponse.getWriterProfileImageUrl()).isEqualTo(mockUser.getMypet().getPetImageUrl());
+        Assertions.assertThat(commentInfoResponse.getDescription()).isEqualTo(commentUpdateRequest.getDescription());
+        Assertions.assertThat(commentInfoResponse.getWriter()).isEqualTo(mockUser.getNickname());
+    }
+
+}

--- a/src/test/java/com/kusitms/samsion/common/consts/TestConst.java
+++ b/src/test/java/com/kusitms/samsion/common/consts/TestConst.java
@@ -30,6 +30,10 @@ public class TestConst {
 
 	// 댓글
 	public static final Long TEST_COMMENT_ID = 1L;
+	public static final Long TEST_CHILD_ID = 2L;
+	public static final String TEST_COMMENT_DESCRIPTION = "testCommentDescription";
+	public static final String TEST_CHILD_COMMENT_DESCRIPTION = "testChildCommentDescription";
+	public static final String TEST_UPDATE_COMMENT_DESCRIPTION = "testUpdateCommentDescription";
 
 
 	// 질문

--- a/src/test/java/com/kusitms/samsion/presentation/comment/CommentControllerTest.java
+++ b/src/test/java/com/kusitms/samsion/presentation/comment/CommentControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import com.kusitms.samsion.application.comment.dto.request.CommentUpdateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -119,7 +120,7 @@ public class CommentControllerTest extends CommonRestDocs{
     @Test
     void 댓글_수정() throws Exception {
         //given
-        CommentCreateRequest commentCreateRequest = new CommentCreateRequest("test");
+        CommentUpdateRequest commentUpdateRequest = new CommentUpdateRequest("test");
         CommentInfoResponse commentInfoResponse = CommentInfoResponse.builder()
                 .description("test")
                 .writer("test")
@@ -132,7 +133,7 @@ public class CommentControllerTest extends CommonRestDocs{
                 put("/album/comment/{commentId}", TestConst.TEST_COMMENT_ID)
                         .header(ApplicationConst.ACCESS_TOKEN_HEADER, "access token")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(commentCreateRequest))
+                        .content(objectMapper.writeValueAsString(commentUpdateRequest))
         );
 
         //then

--- a/src/test/java/com/kusitms/samsion/presentation/comment/CommentControllerTest.java
+++ b/src/test/java/com/kusitms/samsion/presentation/comment/CommentControllerTest.java
@@ -1,14 +1,13 @@
 package com.kusitms.samsion.presentation.comment;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
-import static org.springframework.restdocs.headers.HeaderDocumentation.*;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
+import com.kusitms.samsion.application.comment.dto.request.CommentCreateRequest;
 import com.kusitms.samsion.application.comment.dto.request.CommentUpdateRequest;
+import com.kusitms.samsion.application.comment.dto.response.CommentInfoResponse;
+import com.kusitms.samsion.application.comment.service.CommentCreateService;
+import com.kusitms.samsion.application.comment.service.CommentUpdateService;
+import com.kusitms.samsion.common.consts.ApplicationConst;
+import com.kusitms.samsion.common.consts.TestConst;
+import com.kusitms.samsion.presentation.config.CommonRestDocs;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -16,13 +15,16 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.kusitms.samsion.application.comment.dto.request.CommentCreateRequest;
-import com.kusitms.samsion.application.comment.dto.response.CommentInfoResponse;
-import com.kusitms.samsion.application.comment.service.CommentCreateService;
-import com.kusitms.samsion.application.comment.service.CommentUpdateService;
-import com.kusitms.samsion.common.consts.ApplicationConst;
-import com.kusitms.samsion.common.consts.TestConst;
-import com.kusitms.samsion.presentation.config.CommonRestDocs;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(CommentController.class)
 @DisplayName("CommentController 테스트")
@@ -36,11 +38,11 @@ public class CommentControllerTest extends CommonRestDocs{
     @Test
     void 댓글_저장() throws Exception {
         //given
-        CommentCreateRequest commentCreateRequest = new CommentCreateRequest("test");
+        CommentCreateRequest commentCreateRequest = new CommentCreateRequest(TestConst.TEST_COMMENT_DESCRIPTION);
         CommentInfoResponse commentInfoResponse = CommentInfoResponse.builder()
-                .description("test")
-                .writer("test")
-                .writerProfileImageUrl("test")
+                .description(TestConst.TEST_COMMENT_DESCRIPTION)
+                .writer(TestConst.TEST_NICKNAME)
+                .writerProfileImageUrl(TestConst.TEST_PET_IMAGE_URL)
                 .build();
         given(commentCreateService.createComment(any(), any())).willReturn(commentInfoResponse);
 
@@ -77,11 +79,11 @@ public class CommentControllerTest extends CommonRestDocs{
     @Test
     void 대댓글_저장() throws Exception {
         //given
-        CommentCreateRequest commentCreateRequest = new CommentCreateRequest("test");
+        CommentCreateRequest commentCreateRequest = new CommentCreateRequest(TestConst.TEST_CHILD_COMMENT_DESCRIPTION);
         CommentInfoResponse commentInfoResponse = CommentInfoResponse.builder()
-                .description("test")
-                .writer("test")
-                .writerProfileImageUrl("test")
+                .description(TestConst.TEST_CHILD_COMMENT_DESCRIPTION)
+                .writer(TestConst.TEST_NICKNAME)
+                .writerProfileImageUrl(TestConst.TEST_PET_IMAGE_URL)
                 .build();
         given(commentCreateService.createReComment(any(), any(), any())).willReturn(commentInfoResponse);
 
@@ -120,11 +122,11 @@ public class CommentControllerTest extends CommonRestDocs{
     @Test
     void 댓글_수정() throws Exception {
         //given
-        CommentUpdateRequest commentUpdateRequest = new CommentUpdateRequest("test");
+        CommentUpdateRequest commentUpdateRequest = new CommentUpdateRequest(TestConst.TEST_UPDATE_COMMENT_DESCRIPTION);
         CommentInfoResponse commentInfoResponse = CommentInfoResponse.builder()
-                .description("test")
-                .writer("test")
-                .writerProfileImageUrl("test")
+                .description(TestConst.TEST_UPDATE_COMMENT_DESCRIPTION)
+                .writer(TestConst.TEST_NICKNAME)
+                .writerProfileImageUrl(TestConst.TEST_PET_IMAGE_URL)
                 .build();
         given(commentUpdateService.updateComment(any(), any())).willReturn(commentInfoResponse);
 


### PR DESCRIPTION
# Summary

- 연관관계 메서드 생성자에서 사용하게 변경
- application test code 작성
- 댓글 수정, 생성 request 클래스 분리
- 테스트 상수 댓글, 자식 댓글, 수정 댓글 description 분리
- RestDocs 빌드 시 경로 못 찾는 문제 해결 


# Issue

---


# References

---


