### PR TITLE
[feat] 나의 앨범 조회 기능 추가 및 오류 수정

### DIFF
--- a/src/main/java/com/kusitms/samsion/domain/album/application/service/AlbumCreateUseCase.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/application/service/AlbumCreateUseCase.java
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 
 @UseCase
 @RequiredArgsConstructor
-public class AlbumCreateUserCase {
+public class AlbumCreateUseCase {
 
 	private final UserUtils userUtils;
 	private final AlbumSaveService albumSaveService;

--- a/src/main/java/com/kusitms/samsion/domain/album/domain/repository/AlbumRepositoryCustom.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/domain/repository/AlbumRepositoryCustom.java
@@ -5,11 +5,13 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-import com.kusitms.samsion.domain.album.domain.entity.SortType;
 import com.kusitms.samsion.domain.album.domain.entity.Album;
 import com.kusitms.samsion.domain.album.domain.entity.EmotionTag;
+import com.kusitms.samsion.domain.album.domain.entity.SortType;
 
 public interface AlbumRepositoryCustom {
 
 	Slice<Album> findAlbumList(Pageable pageable, List<EmotionTag> emotionTagList, SortType sortType);
+
+	Slice<Album> findMyAlbumList(Pageable pageable, List<EmotionTag> emotionTagList, SortType sortType, Long userId);
 }

--- a/src/main/java/com/kusitms/samsion/domain/album/domain/service/AlbumQueryService.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/domain/service/AlbumQueryService.java
@@ -7,9 +7,9 @@ import org.springframework.data.domain.Slice;
 
 import com.kusitms.samsion.common.annotation.DomainService;
 import com.kusitms.samsion.common.exception.Error;
-import com.kusitms.samsion.domain.album.domain.entity.SortType;
 import com.kusitms.samsion.domain.album.domain.entity.Album;
 import com.kusitms.samsion.domain.album.domain.entity.EmotionTag;
+import com.kusitms.samsion.domain.album.domain.entity.SortType;
 import com.kusitms.samsion.domain.album.domain.exception.AlbumNotFoundException;
 import com.kusitms.samsion.domain.album.domain.repository.AlbumRepository;
 
@@ -27,6 +27,10 @@ public class AlbumQueryService {
 
 	public Slice<Album> getAlbumList(Pageable pageable, List<EmotionTag> emotionTagList, SortType sortType){
 		return albumRepository.findAlbumList(pageable, emotionTagList, sortType);
+	}
+
+	public Slice<Album> getMyAlbumList(Pageable pageable, List<EmotionTag> emotionTagList, SortType sortType, Long userId){
+		return albumRepository.findMyAlbumList(pageable, emotionTagList, sortType, userId);
 	}
 
 }

--- a/src/main/java/com/kusitms/samsion/domain/album/presentation/AlbumController.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/presentation/AlbumController.java
@@ -13,8 +13,8 @@ import com.kusitms.samsion.domain.album.application.dto.request.AlbumCreateReque
 import com.kusitms.samsion.domain.album.application.dto.request.AlbumSearchRequest;
 import com.kusitms.samsion.domain.album.application.dto.response.AlbumInfoResponse;
 import com.kusitms.samsion.domain.album.application.dto.response.AlbumSimpleResponse;
-import com.kusitms.samsion.domain.album.application.service.AlbumCreateUserCase;
-import com.kusitms.samsion.domain.album.application.service.AlbumReadUserCase;
+import com.kusitms.samsion.domain.album.application.service.AlbumCreateUseCase;
+import com.kusitms.samsion.domain.album.application.service.AlbumReadUseCase;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,20 +26,23 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/album")
 public class AlbumController {
 
-	private final AlbumReadUserCase albumReadUserCase;
-	private final AlbumCreateUserCase albumCreateUserCase;
+	private final AlbumReadUseCase albumReadUseCase;
+	private final AlbumCreateUseCase albumCreateUseCase;
 
 	/**
-	 * @param pageable : page, size
-	 *                 sort : DEFUALT
 	 * 기존 jpa : 앨범 10개 조회 기준, 3회 warmup, 4회 테스트 평균 853ms
 	 * QueryDsl : 앨범 10개 조회 기준, 3회 warmup, 4회 테스트 평균 347ms
 	 */
 	@GetMapping
-	public SliceResponse<AlbumSimpleResponse> getAlbumList(Pageable pageable, @ModelAttribute
-		AlbumSearchRequest request){
-		return albumReadUserCase.getAlbumList(pageable, request);
+	public SliceResponse<AlbumSimpleResponse> getAlbumList(Pageable pageable, @ModelAttribute AlbumSearchRequest request){
+		return albumReadUseCase.getAlbumList(pageable, request);
 	}
+
+	@GetMapping("/private")
+	public SliceResponse<AlbumSimpleResponse> getMyAlbumList(Pageable pageable, @ModelAttribute AlbumSearchRequest request){
+		return albumReadUseCase.getMyAlbumList(pageable, request);
+	}
+
 
 	/**
 	 * 이미지 2개, 태그 5개 기준으로 생성시간 3회 warmup, 4회 테스트 진행시 평균 1000ms
@@ -47,12 +50,12 @@ public class AlbumController {
 	 */
 	@PostMapping()
 	public AlbumInfoResponse createAlbum(@ModelAttribute AlbumCreateRequest request){
-		return albumCreateUserCase.createAlbum(request);
+		return albumCreateUseCase.createAlbum(request);
 	}
 
 	@GetMapping("/{albumId}")
 	public AlbumInfoResponse getAlbum(@PathVariable Long albumId){
-		return albumReadUserCase.getAlbum(albumId);
+		return albumReadUseCase.getAlbum(albumId);
 	}
 
 }

--- a/src/main/java/com/kusitms/samsion/domain/empathy/domain/service/EmpathyQueryService.java
+++ b/src/main/java/com/kusitms/samsion/domain/empathy/domain/service/EmpathyQueryService.java
@@ -15,7 +15,7 @@ public class EmpathyQueryService {
 	private final EmpathyRepository empathyRepository;
 
 	public boolean isEmpathyByUserIdAndAlbumId(Long userId, Long albumId){
-		return empathyRepository.existsByUserIdAndAlbumId(albumId, userId);
+		return empathyRepository.existsByUserIdAndAlbumId(userId, albumId);
 	}
 
 	public long getEmpathyCountByAlbumId(Long albumId){


### PR DESCRIPTION
# Summary

---

* 나의 앨범 리스트 조회 Api 추가
* Album UseCase 클래스 이름 오타 수정
* 공감 repository의 메서드(existsByUserIdAndAlbumId) 파라미터 순서 잘못들어가서 수정

# Issue

---


# References

---


