### PR TITLE
[feat] Grid 도메인(등록, 조회, 스탬프 조회) 및 Grid 카운트 증가 이벤트 로직 추가

### DIFF
--- a/src/main/java/com/kusitms/samsion/common/exception/Error.java
+++ b/src/main/java/com/kusitms/samsion/common/exception/Error.java
@@ -18,17 +18,22 @@ public enum Error {
 	// 공감
 	EMPATHY_NOT_FOUND("공감을 찾을 수 없습니다.", 3000),
 
-	//댓글
-	COMMENT_NOT_FOUND("댓글을 찾을 수 없습니다.", 5000),
 
 	// 질문
 	QUESTION_NOT_FOUND("질문을 찾을 수 없습니다.", 4000),
 	ANSWER_NOT_FOUND("답변을 찾을 수 없습니다.", 4001),
 	ANSWER_ALREADY_EXIST("이미 답변이 존재합니다.", 4002),
 
+	//댓글,
+	COMMENT_NOT_FOUND("댓글을 찾을 수 없습니다.", 5000),
+
+	// 그리드
+	GRID_NOT_REGISTERED("그리드를 찾을 수 없습니다.", 6000),
+	GRID_ALREADY_REGISTERED("이미 그리드가 존재합니다.", 6001),
+
 	// JWT
-	INVALID_TOKEN("잘못된 토큰 요청", 4001),
-	EXPIRED_TOKEN("토큰 만료", 4002);
+	INVALID_TOKEN("잘못된 토큰 요청", 7000),
+	EXPIRED_TOKEN("토큰 만료", 7001);
 
 	private final String message;
 	private final int errorCode;

--- a/src/main/java/com/kusitms/samsion/common/slice/ListResponse.java
+++ b/src/main/java/com/kusitms/samsion/common/slice/ListResponse.java
@@ -1,0 +1,19 @@
+package com.kusitms.samsion.common.slice;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class ListResponse<T> {
+
+	private List<T> content;
+
+	private ListResponse(List<T> content) {
+		this.content = content;
+	}
+
+	public static <T> ListResponse<T> of(List<T> list) {
+		return new ListResponse<>(list);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/common/slice/SliceResponse.java
+++ b/src/main/java/com/kusitms/samsion/common/slice/SliceResponse.java
@@ -14,7 +14,7 @@ public class SliceResponse<T> {
 	private final int size;
 	private final boolean hasNext;
 
-	public SliceResponse(List<T> content, int page, int size, boolean hasNext) {
+	private SliceResponse(List<T> content, int page, int size, boolean hasNext) {
 		this.content = content;
 		this.page = page;
 		this.size = size;

--- a/src/main/java/com/kusitms/samsion/common/util/UserUtils.java
+++ b/src/main/java/com/kusitms/samsion/common/util/UserUtils.java
@@ -15,6 +15,6 @@ public class UserUtils {
 
 	public User getUser(){
 		final String userEmail = SecurityUtils.getUserEmail();
-		return userQueryService.getUserByEmail(userEmail);
+		return userQueryService.findByEmail(userEmail);
 	}
 }

--- a/src/main/java/com/kusitms/samsion/domain/album/application/dto/response/AlbumSimpleResponse.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/application/dto/response/AlbumSimpleResponse.java
@@ -6,14 +6,14 @@ import lombok.Getter;
 @Getter
 public class AlbumSimpleResponse {
 
-	private final Long id;
+	private final Long albumId;
 	private final String imageUrl;
 	private final long empathyCount;
 	private final long commentCount;
 
 	@Builder
-	public AlbumSimpleResponse(Long id, String imageUrl, long empathyCount, long commentCount) {
-		this.id = id;
+	public AlbumSimpleResponse(Long albumId, String imageUrl, long empathyCount, long commentCount) {
+		this.albumId = albumId;
 		this.imageUrl = imageUrl;
 		this.empathyCount = empathyCount;
 		this.commentCount = commentCount;

--- a/src/main/java/com/kusitms/samsion/domain/album/application/mapper/AlbumMapper.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/application/mapper/AlbumMapper.java
@@ -15,7 +15,7 @@ public class AlbumMapper {
 
 	public static AlbumSimpleResponse mapToAlbumSimpleResponse(Album album, long commentCnt, long empathyCnt) {
 		return AlbumSimpleResponse.builder()
-			.id(album.getId())
+			.albumId(album.getId())
 			.imageUrl(album.getAlbumImages().get(0).getImageUrl())
 			.commentCount(commentCnt)
 			.empathyCount(empathyCnt)

--- a/src/main/java/com/kusitms/samsion/domain/album/application/service/AlbumCreateUseCase.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/application/service/AlbumCreateUseCase.java
@@ -15,11 +15,13 @@ import com.kusitms.samsion.domain.album.domain.entity.Album;
 import com.kusitms.samsion.domain.album.domain.service.AlbumImageSaveService;
 import com.kusitms.samsion.domain.album.domain.service.AlbumSaveService;
 import com.kusitms.samsion.domain.album.domain.service.TagSaveService;
+import com.kusitms.samsion.domain.grid.application.dto.request.GridCountUpdateRequest;
 import com.kusitms.samsion.domain.user.domain.entity.User;
 
 import lombok.RequiredArgsConstructor;
 
 @UseCase
+@Transactional
 @RequiredArgsConstructor
 public class AlbumCreateUseCase {
 
@@ -34,7 +36,6 @@ public class AlbumCreateUseCase {
 	/**
 	 * TODO : 의존성이 너무 과한것같음, Album, AlbumImage, Tag을 같은 aggregate로 묶었지만 Album저장로직에 너무 많은 의존성이 생겨버림 이벤트 기반으로 변경할지고민중
 	 */
-	@Transactional
 	public AlbumInfoResponse createAlbum(AlbumCreateRequest albumCreateRequest){
 		List<String> imageUrls = s3UploadService.uploadImgList(albumCreateRequest.getAlbumImages());
 
@@ -44,7 +45,7 @@ public class AlbumCreateUseCase {
 		tagSaveService.saveTagList(albumCreateRequest.getEmotionTags(), album);
 		albumImageSaveService.saveAlbumImageList(imageUrls, album);
 
-
+		applicationEventPublisher.publishEvent(new GridCountUpdateRequest(user.getId()));
 
 		return AlbumMapper.mapToAlbumInfoResponse(album);
 	}

--- a/src/main/java/com/kusitms/samsion/domain/grid/application/dto/GridCheck.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/application/dto/GridCheck.java
@@ -1,0 +1,14 @@
+package com.kusitms.samsion.domain.grid.application.dto;
+
+import lombok.Getter;
+
+@Getter
+public class GridCheck {
+	private final boolean isCheck;
+	private final int gridNum;
+
+	public GridCheck(boolean isCheck, int gridNum) {
+		this.isCheck = isCheck;
+		this.gridNum = gridNum;
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/application/dto/request/GridCountUpdateRequest.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/application/dto/request/GridCountUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.kusitms.samsion.domain.grid.application.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class GridCountUpdateRequest {
+
+	private Long userId;
+
+	public GridCountUpdateRequest(Long userId) {
+		this.userId = userId;
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/application/dto/request/GridRegisterRequest.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/application/dto/request/GridRegisterRequest.java
@@ -1,0 +1,15 @@
+package com.kusitms.samsion.domain.grid.application.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.Getter;
+
+@Getter
+public class GridRegisterRequest {
+
+	private MultipartFile gridImage;
+
+	public GridRegisterRequest(MultipartFile gridImage) {
+		this.gridImage = gridImage;
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/application/dto/response/GridInfoResponse.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/application/dto/response/GridInfoResponse.java
@@ -1,0 +1,19 @@
+package com.kusitms.samsion.domain.grid.application.dto.response;
+
+import java.util.List;
+
+import com.kusitms.samsion.domain.grid.application.dto.GridCheck;
+
+import lombok.Getter;
+
+@Getter
+public class GridInfoResponse {
+
+	private final List<GridCheck> gridCheckList;
+	private final String gridImageUrl;
+
+	public GridInfoResponse(List<GridCheck> gridCheckList, String gridImageUrl) {
+		this.gridCheckList = gridCheckList;
+		this.gridImageUrl = gridImageUrl;
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/application/dto/response/StampResponse.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/application/dto/response/StampResponse.java
@@ -1,0 +1,16 @@
+package com.kusitms.samsion.domain.grid.application.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class StampResponse {
+
+	private final Long stampId;
+	private final String imageUrl;
+
+	public StampResponse(Long stampId, String imageUrl) {
+		this.stampId = stampId;
+		this.imageUrl = imageUrl;
+	}
+
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/application/handler/GridCountUpdateHandler.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/application/handler/GridCountUpdateHandler.java
@@ -1,0 +1,54 @@
+package com.kusitms.samsion.domain.grid.application.handler;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.kusitms.samsion.common.annotation.UseCase;
+import com.kusitms.samsion.domain.grid.application.dto.request.GridCountUpdateRequest;
+import com.kusitms.samsion.domain.grid.domain.entity.Grid;
+import com.kusitms.samsion.domain.grid.domain.entity.GridCountTracker;
+import com.kusitms.samsion.domain.grid.domain.exception.GridNotRegisteredException;
+import com.kusitms.samsion.domain.grid.domain.service.GridCountTrackerQueryService;
+import com.kusitms.samsion.domain.grid.domain.service.GridCountTrackerSaveService;
+import com.kusitms.samsion.domain.grid.domain.service.GridQueryService;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+import com.kusitms.samsion.domain.user.domain.service.UserQueryService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@UseCase
+@Transactional
+@Slf4j
+@RequiredArgsConstructor
+public class GridCountUpdateHandler {
+
+	private final UserQueryService userQueryService;
+	private final GridQueryService gridQueryService;
+	private final GridCountTrackerQueryService gridCountTrackerQueryService;
+	private final GridCountTrackerSaveService gridCountTrackerSaveService;
+
+	@TransactionalEventListener
+	public void updateGridCount(GridCountUpdateRequest request) {
+		Thread thread = Thread.currentThread();
+		log.info("EventListener Thread : {}", thread.getName());
+		User user = userQueryService.findById(request.getUserId());
+		Grid grid;
+		try {
+			grid = gridQueryService.findGridByUserId(user.getId());
+			Optional<GridCountTracker> gridCountTracker = gridCountTrackerQueryService.findGridCountByGridId(
+				grid.getId());
+			if (gridCountTracker.isEmpty()) {
+				gridCountTrackerSaveService.saveGridCountTracker(new GridCountTracker(grid.getId(), LocalDateTime.now()));
+				grid.incGridCnt();
+				if (grid.getGridCnt() == 60) {
+					grid.updateGridStatus();
+				}
+			}
+		} catch (GridNotRegisteredException ignored){}
+	}
+
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/application/mapper/GridMapper.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/application/mapper/GridMapper.java
@@ -1,0 +1,39 @@
+package com.kusitms.samsion.domain.grid.application.mapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.kusitms.samsion.common.annotation.Mapper;
+import com.kusitms.samsion.domain.grid.application.dto.GridCheck;
+import com.kusitms.samsion.domain.grid.application.dto.response.GridInfoResponse;
+import com.kusitms.samsion.domain.grid.application.dto.response.StampResponse;
+import com.kusitms.samsion.domain.grid.domain.entity.Grid;
+
+@Mapper
+public class GridMapper {
+
+	public static GridInfoResponse mapToGridInfoResponse(Grid grid) {
+		final int gridCnt = grid.getGridCnt();
+		List<GridCheck> gridCheckList = new ArrayList<>();
+		for(int i =1; i< 60;i++){
+			if(i<=gridCnt)
+				gridCheckList.add(new GridCheck(true, i));
+			else
+				gridCheckList.add(new GridCheck(false, i));
+		}
+
+		return new GridInfoResponse(gridCheckList, grid.getGridImageUrl());
+	}
+
+	public static StampResponse mapToStampResponse(Grid grid) {
+		return new StampResponse(grid.getId(), grid.getGridImageUrl());
+	}
+
+	public static List<StampResponse> mapToStampResponseList(List<Grid> stampList) {
+		List<StampResponse> stampResponseList = stampList.stream()
+			.map(GridMapper::mapToStampResponse)
+			.collect(Collectors.toList());
+		return stampResponseList;
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/application/service/GridGetUseCase.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/application/service/GridGetUseCase.java
@@ -1,0 +1,28 @@
+package com.kusitms.samsion.domain.grid.application.service;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kusitms.samsion.common.annotation.UseCase;
+import com.kusitms.samsion.common.util.UserUtils;
+import com.kusitms.samsion.domain.grid.application.dto.response.GridInfoResponse;
+import com.kusitms.samsion.domain.grid.application.mapper.GridMapper;
+import com.kusitms.samsion.domain.grid.domain.entity.Grid;
+import com.kusitms.samsion.domain.grid.domain.service.GridQueryService;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GridGetUseCase {
+
+	private final UserUtils userUtils;
+	private final GridQueryService gridQueryService;
+
+	public GridInfoResponse getGrid(){
+		User user = userUtils.getUser();
+		Grid grid = gridQueryService.findGridByUserId(user.getId());
+		return GridMapper.mapToGridInfoResponse(grid);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/application/service/GridRegisterUseCase.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/application/service/GridRegisterUseCase.java
@@ -1,0 +1,32 @@
+package com.kusitms.samsion.domain.grid.application.service;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kusitms.samsion.common.annotation.UseCase;
+import com.kusitms.samsion.common.infrastructure.s3.S3UploadService;
+import com.kusitms.samsion.common.util.UserUtils;
+import com.kusitms.samsion.domain.grid.application.dto.request.GridRegisterRequest;
+import com.kusitms.samsion.domain.grid.domain.entity.Grid;
+import com.kusitms.samsion.domain.grid.domain.service.GridSaveService;
+import com.kusitms.samsion.domain.grid.domain.service.GridValidateService;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class GridRegisterUseCase {
+
+	private final UserUtils userUtils;
+	private final GridSaveService gridSaveService;
+	private final GridValidateService gridValidateService;
+	private final S3UploadService s3UploadService;
+
+	public void registerGrid(GridRegisterRequest request) {
+		User user = userUtils.getUser();
+		gridValidateService.validateGridRegistered(user.getId());
+		final String gridImageUrl = s3UploadService.uploadImg(request.getGridImage());
+		gridSaveService.saveGrid(new Grid(gridImageUrl, user));
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/application/service/StampGetUseCase.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/application/service/StampGetUseCase.java
@@ -1,0 +1,31 @@
+package com.kusitms.samsion.domain.grid.application.service;
+
+import java.util.List;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kusitms.samsion.common.annotation.UseCase;
+import com.kusitms.samsion.common.slice.ListResponse;
+import com.kusitms.samsion.common.util.UserUtils;
+import com.kusitms.samsion.domain.grid.application.dto.response.StampResponse;
+import com.kusitms.samsion.domain.grid.application.mapper.GridMapper;
+import com.kusitms.samsion.domain.grid.domain.entity.Grid;
+import com.kusitms.samsion.domain.grid.domain.service.GridQueryService;
+
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class StampGetUseCase {
+
+	private final UserUtils userUtils;
+	private final GridQueryService gridQueryService;
+
+	public ListResponse<StampResponse> getStampList(){
+		Long userId = userUtils.getUser().getId();
+		List<Grid> stampList = gridQueryService.findStampByUserId(userId);
+		List<StampResponse> stampResponseList = GridMapper.mapToStampResponseList(stampList);
+		return ListResponse.of(stampResponseList);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/domain/entity/Grid.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/domain/entity/Grid.java
@@ -1,0 +1,60 @@
+package com.kusitms.samsion.domain.grid.domain.entity;
+
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import com.kusitms.samsion.common.domain.BaseEntity;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Grid extends BaseEntity {
+
+	@Id@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "grid_id")
+	private Long id;
+
+	private String gridImageUrl;
+	private int gridCnt;
+
+	@Enumerated(EnumType.STRING)
+	private GridStatus gridStatus;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	public Grid(String gridImageUrl, User user) {
+		this.gridImageUrl = gridImageUrl;
+		this.gridCnt = 0;
+		this.gridStatus = GridStatus.GRID;
+		this.user = user;
+	}
+
+	public void incGridCnt(){
+		if(gridCnt<60&& Objects.equals(gridStatus, GridStatus.GRID)) {
+			this.gridCnt++;
+		}
+	}
+
+	public void updateGridStatus(){
+		if(gridCnt == 60) {
+			this.gridStatus = GridStatus.STAMP;
+		}
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/domain/entity/GridCountTracker.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/domain/entity/GridCountTracker.java
@@ -1,0 +1,39 @@
+package com.kusitms.samsion.domain.grid.domain.entity;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import javax.persistence.Id;
+
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@RedisHash(value = "gridCountTracker", timeToLive = 60 * 60 * 24)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GridCountTracker implements Serializable {
+
+	@Id
+	private Long id;
+	@Indexed
+	private Long gridId;
+	private LocalDateTime createdDate;
+
+	public GridCountTracker(Long gridId, LocalDateTime createdDate) {
+		this.gridId = gridId;
+		this.createdDate = createdDate;
+	}
+
+	@Override
+	public String toString() {
+		return "GridCountTracker{" +
+			"id=" + id +
+			", gridId=" + gridId +
+			", createdDate=" + createdDate +
+			'}';
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/domain/entity/GridStatus.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/domain/entity/GridStatus.java
@@ -1,0 +1,6 @@
+package com.kusitms.samsion.domain.grid.domain.entity;
+
+public enum GridStatus {
+	GRID,
+	STAMP;
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/domain/exception/GridAlreadyRegisteredException.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/domain/exception/GridAlreadyRegisteredException.java
@@ -1,0 +1,9 @@
+package com.kusitms.samsion.domain.grid.domain.exception;
+
+import com.kusitms.samsion.common.exception.Error;
+
+public class GridAlreadyRegisteredException extends GridException {
+	public GridAlreadyRegisteredException(Error error) {
+		super(error);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/domain/exception/GridException.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/domain/exception/GridException.java
@@ -1,0 +1,10 @@
+package com.kusitms.samsion.domain.grid.domain.exception;
+
+import com.kusitms.samsion.common.exception.BusinessException;
+import com.kusitms.samsion.common.exception.Error;
+
+public class GridException extends BusinessException {
+	public GridException(Error error) {
+		super(error);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/domain/exception/GridNotRegisteredException.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/domain/exception/GridNotRegisteredException.java
@@ -1,0 +1,10 @@
+package com.kusitms.samsion.domain.grid.domain.exception;
+
+import com.kusitms.samsion.common.exception.Error;
+
+public class GridNotRegisteredException extends GridException {
+
+	public GridNotRegisteredException(Error error) {
+		super(error);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/domain/repository/GridRedisRepository.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/domain/repository/GridRedisRepository.java
@@ -1,0 +1,13 @@
+package com.kusitms.samsion.domain.grid.domain.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.kusitms.samsion.domain.grid.domain.entity.GridCountTracker;
+
+public interface GridRedisRepository extends CrudRepository<GridCountTracker, Long> {
+
+	List<GridCountTracker> findByGridId(Long gridId);
+
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/domain/repository/GridRepository.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/domain/repository/GridRepository.java
@@ -1,0 +1,22 @@
+package com.kusitms.samsion.domain.grid.domain.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.kusitms.samsion.domain.grid.domain.entity.Grid;
+
+public interface GridRepository extends JpaRepository<Grid, Long> {
+
+	@Query("select g from Grid g where g.user.id = :userId and g.gridStatus = 'GRID'")
+	Optional<Grid> findGridByUserId(@Param("userId") Long userId);
+
+	@Query("select g from Grid g where g.user.id = :userId and g.gridStatus = 'STAMP' and g.gridCnt = 60")
+	List<Grid> findStampListByUserId(@Param("userId") Long userId);
+
+	@Query("select count (g) > 0 from Grid g where g.user.id = :userId and g.gridStatus = 'GRID'")
+	boolean existsGridByUserId(Long userId);
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/domain/service/GridCountTrackerQueryService.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/domain/service/GridCountTrackerQueryService.java
@@ -1,0 +1,36 @@
+package com.kusitms.samsion.domain.grid.domain.service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kusitms.samsion.common.annotation.DomainService;
+import com.kusitms.samsion.domain.grid.domain.entity.GridCountTracker;
+import com.kusitms.samsion.domain.grid.domain.repository.GridRedisRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Transactional(readOnly = true)
+@DomainService
+@RequiredArgsConstructor
+public class GridCountTrackerQueryService {
+
+	private final GridRedisRepository gridRedisRepository;
+
+	public Optional<GridCountTracker> findGridCountByGridId(Long gridId) {
+		List<GridCountTracker> gridCountTrackerList = gridRedisRepository.findByGridId(gridId);
+		log.info("gridCountTrackerList : {}", gridCountTrackerList);
+		if(gridCountTrackerList.size() == 0) {
+			return Optional.empty();
+		}
+
+		return gridCountTrackerList.stream()
+			.filter(gridCountTracker -> gridCountTracker.getCreatedDate().isAfter(LocalDate.now().atStartOfDay()))
+			.findFirst();
+	}
+
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/domain/service/GridCountTrackerSaveService.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/domain/service/GridCountTrackerSaveService.java
@@ -1,0 +1,18 @@
+package com.kusitms.samsion.domain.grid.domain.service;
+
+import com.kusitms.samsion.common.annotation.DomainService;
+import com.kusitms.samsion.domain.grid.domain.entity.GridCountTracker;
+import com.kusitms.samsion.domain.grid.domain.repository.GridRedisRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class GridCountTrackerSaveService {
+
+	private final GridRedisRepository gridRedisRepository;
+
+	public void saveGridCountTracker(GridCountTracker gridCountTracker) {
+		gridRedisRepository.save(gridCountTracker);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/domain/service/GridQueryService.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/domain/service/GridQueryService.java
@@ -1,0 +1,34 @@
+package com.kusitms.samsion.domain.grid.domain.service;
+
+import java.util.List;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kusitms.samsion.common.annotation.DomainService;
+import com.kusitms.samsion.common.exception.Error;
+import com.kusitms.samsion.domain.grid.domain.entity.Grid;
+import com.kusitms.samsion.domain.grid.domain.exception.GridNotRegisteredException;
+import com.kusitms.samsion.domain.grid.domain.repository.GridRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Transactional(readOnly = true)
+@DomainService
+@RequiredArgsConstructor
+public class GridQueryService {
+
+	private final GridRepository gridRepository;
+
+	public Grid findGridByUserId(Long userId) {
+		return gridRepository.findGridByUserId(userId)
+			.orElseThrow(()-> new GridNotRegisteredException(Error.GRID_NOT_REGISTERED));
+	}
+
+	public boolean isGridRegistered(Long userId) {
+		return gridRepository.existsGridByUserId(userId);
+	}
+
+	public List<Grid> findStampByUserId(Long userId){
+		return gridRepository.findStampListByUserId(userId);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/domain/service/GridSaveService.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/domain/service/GridSaveService.java
@@ -1,0 +1,18 @@
+package com.kusitms.samsion.domain.grid.domain.service;
+
+import com.kusitms.samsion.common.annotation.DomainService;
+import com.kusitms.samsion.domain.grid.domain.entity.Grid;
+import com.kusitms.samsion.domain.grid.domain.repository.GridRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class GridSaveService {
+
+	private final GridRepository gridRepository;
+
+	public void saveGrid(Grid grid) {
+		gridRepository.save(grid);
+	}
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/domain/service/GridValidateService.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/domain/service/GridValidateService.java
@@ -1,0 +1,22 @@
+package com.kusitms.samsion.domain.grid.domain.service;
+
+import com.kusitms.samsion.common.annotation.DomainService;
+import com.kusitms.samsion.common.exception.Error;
+import com.kusitms.samsion.domain.grid.domain.exception.GridAlreadyRegisteredException;
+import com.kusitms.samsion.domain.grid.domain.repository.GridRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class GridValidateService {
+
+	private final GridRepository gridRepository;
+
+	public void validateGridRegistered(Long userId) {
+		if(gridRepository.existsGridByUserId(userId)) {
+			throw new GridAlreadyRegisteredException(Error.GRID_ALREADY_REGISTERED);
+		}
+	}
+
+}

--- a/src/main/java/com/kusitms/samsion/domain/grid/presentation/GridController.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/presentation/GridController.java
@@ -1,0 +1,43 @@
+package com.kusitms.samsion.domain.grid.presentation;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kusitms.samsion.common.slice.ListResponse;
+import com.kusitms.samsion.domain.grid.application.dto.request.GridRegisterRequest;
+import com.kusitms.samsion.domain.grid.application.dto.response.GridInfoResponse;
+import com.kusitms.samsion.domain.grid.application.dto.response.StampResponse;
+import com.kusitms.samsion.domain.grid.application.service.GridGetUseCase;
+import com.kusitms.samsion.domain.grid.application.service.GridRegisterUseCase;
+import com.kusitms.samsion.domain.grid.application.service.StampGetUseCase;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/grid")
+public class GridController {
+
+	private final GridGetUseCase gridGetUseCase;
+	private final StampGetUseCase stampGetUseCase;
+	private final GridRegisterUseCase gridRegisterUseCase;
+
+	@GetMapping
+	public GridInfoResponse getGrid() {
+		return gridGetUseCase.getGrid();
+	}
+
+	@GetMapping("/stamp")
+	public ListResponse<StampResponse> getStamp(){
+		return stampGetUseCase.getStampList();
+	}
+
+	@PostMapping
+	public void gridRegister(@ModelAttribute GridRegisterRequest request) {
+		gridRegisterUseCase.registerGrid(request);
+	}
+
+}

--- a/src/main/java/com/kusitms/samsion/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/kusitms/samsion/domain/user/domain/repository/UserRepository.java
@@ -8,6 +8,8 @@ import com.kusitms.samsion.domain.user.domain.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
+	Optional<User> findById(Long userId);
+
 	Optional<User> findByEmail(String email);
 
 	boolean existsByEmail(String email);

--- a/src/main/java/com/kusitms/samsion/domain/user/domain/service/UserQueryService.java
+++ b/src/main/java/com/kusitms/samsion/domain/user/domain/service/UserQueryService.java
@@ -11,14 +11,22 @@ import com.kusitms.samsion.domain.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 
 @DomainService
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserQueryService {
 
 	private final UserRepository userRepository;
 
-	@Transactional(readOnly = true)
-	public User getUserByEmail(String email) {
+
+	public User findByEmail(String email) {
 		return userRepository.findByEmail(email)
 			.orElseThrow(() -> new UserNotFoundException(Error.USER_NOT_FOUND));
 	}
+
+	public User findById(Long userId){
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new UserNotFoundException(Error.USER_NOT_FOUND));
+	}
+
+
 }

--- a/src/test/java/com/kusitms/samsion/domain/user/domain/service/UserQueryServiceTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/user/domain/service/UserQueryServiceTest.java
@@ -17,7 +17,6 @@ import com.kusitms.samsion.common.util.UserTestUtils;
 import com.kusitms.samsion.domain.user.domain.entity.User;
 import com.kusitms.samsion.domain.user.domain.exception.UserNotFoundException;
 import com.kusitms.samsion.domain.user.domain.repository.UserRepository;
-import com.kusitms.samsion.domain.user.domain.service.UserQueryService;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("UserGetService 테스트")
@@ -39,7 +38,7 @@ class UserQueryServiceTest {
 		User mockUser = UserTestUtils.getMockUser();
 		given(userRepository.findByEmail(TestConst.TEST_EMAIL)).willReturn(Optional.of(mockUser));
 		//when
-		User user = userQueryService.getUserByEmail(mockUser.getEmail());
+		User user = userQueryService.findByEmail(mockUser.getEmail());
 		//then
 		Assertions.assertThat(user).isNotNull();
 		Assertions.assertThat(user).usingRecursiveComparison().isEqualTo(mockUser);
@@ -51,7 +50,7 @@ class UserQueryServiceTest {
 		given(userRepository.findByEmail(TestConst.TEST_EMAIL)).willReturn(Optional.empty());
 		//when
 		//then
-		Assertions.assertThatThrownBy(() -> userQueryService.getUserByEmail(TestConst.TEST_EMAIL))
+		Assertions.assertThatThrownBy(() -> userQueryService.findByEmail(TestConst.TEST_EMAIL))
 			.isInstanceOf(UserNotFoundException.class);
 	}
 


### PR DESCRIPTION
# Summary

---

* Grid 도메인(등록, 조회, 스탬프 조회) Api 추가
* 사용자가 앨범 등록하면 Redis에서 당일 캐싱된 GridCountTracker 확인 
    1. 없으면 Grid DB에서 찾아와서 값 1 증가
    2. 있으면 아무처리도 안함
* AlbumCreateUseCase에 Grid 카운트 증가 위한 event 등록

# Issue

---


# References

---


