### PR TITLE
[fix] @TransactionalEventListener 처리에서 기존 트랜잭션 유지에 의한 문제 수정

### DIFF
--- a/src/main/java/com/kusitms/samsion/domain/grid/application/handler/GridCountUpdateHandler.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/application/handler/GridCountUpdateHandler.java
@@ -3,6 +3,7 @@ package com.kusitms.samsion.domain.grid.application.handler;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -14,39 +15,28 @@ import com.kusitms.samsion.domain.grid.domain.exception.GridNotRegisteredExcepti
 import com.kusitms.samsion.domain.grid.domain.service.GridCountTrackerQueryService;
 import com.kusitms.samsion.domain.grid.domain.service.GridCountTrackerSaveService;
 import com.kusitms.samsion.domain.grid.domain.service.GridQueryService;
-import com.kusitms.samsion.domain.user.domain.entity.User;
-import com.kusitms.samsion.domain.user.domain.service.UserQueryService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @UseCase
-@Transactional
+@Transactional(propagation = Propagation.REQUIRES_NEW)
 @Slf4j
 @RequiredArgsConstructor
 public class GridCountUpdateHandler {
 
-	private final UserQueryService userQueryService;
 	private final GridQueryService gridQueryService;
 	private final GridCountTrackerQueryService gridCountTrackerQueryService;
 	private final GridCountTrackerSaveService gridCountTrackerSaveService;
 
 	@TransactionalEventListener
 	public void updateGridCount(GridCountUpdateRequest request) {
-		Thread thread = Thread.currentThread();
-		log.info("EventListener Thread : {}", thread.getName());
-		User user = userQueryService.findById(request.getUserId());
-		Grid grid;
 		try {
-			grid = gridQueryService.findGridByUserId(user.getId());
-			Optional<GridCountTracker> gridCountTracker = gridCountTrackerQueryService.findGridCountByGridId(
-				grid.getId());
+			Grid grid = gridQueryService.findGridByUserId(request.getUserId());
+			Optional<GridCountTracker> gridCountTracker = gridCountTrackerQueryService.findGridCountByGridId(grid.getId());
 			if (gridCountTracker.isEmpty()) {
 				gridCountTrackerSaveService.saveGridCountTracker(new GridCountTracker(grid.getId(), LocalDateTime.now()));
 				grid.incGridCnt();
-				if (grid.getGridCnt() == 60) {
-					grid.updateGridStatus();
-				}
 			}
 		} catch (GridNotRegisteredException ignored){}
 	}

--- a/src/main/java/com/kusitms/samsion/domain/grid/domain/entity/Grid.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/domain/entity/Grid.java
@@ -49,10 +49,11 @@ public class Grid extends BaseEntity {
 	public void incGridCnt(){
 		if(gridCnt<60&& Objects.equals(gridStatus, GridStatus.GRID)) {
 			this.gridCnt++;
+			updateGridStatus();
 		}
 	}
 
-	public void updateGridStatus(){
+	private void updateGridStatus(){
 		if(gridCnt == 60) {
 			this.gridStatus = GridStatus.STAMP;
 		}

--- a/src/main/java/com/kusitms/samsion/domain/grid/domain/service/GridCountTrackerQueryService.java
+++ b/src/main/java/com/kusitms/samsion/domain/grid/domain/service/GridCountTrackerQueryService.java
@@ -23,7 +23,6 @@ public class GridCountTrackerQueryService {
 
 	public Optional<GridCountTracker> findGridCountByGridId(Long gridId) {
 		List<GridCountTracker> gridCountTrackerList = gridRedisRepository.findByGridId(gridId);
-		log.info("gridCountTrackerList : {}", gridCountTrackerList);
 		if(gridCountTrackerList.size() == 0) {
 			return Optional.empty();
 		}


### PR DESCRIPTION
# Summary

---

* @TransactionalEventListener을 사용하면 기존 트랜잭션을 유지하므로 새로운 트랜잭션 생성을 통해 커밋이 진행될 수 있도록 수정
* GridCountUpdateHandler 메서드 리팩터링

# Issue

---


# References

---

"EventListener에서 예외가 발생하니 전체 롤백이 되네?" 노션 페이지 수정

