### PR TITLE
[feat] 캐싱 기능 추가

### DIFF
--- a/src/main/java/com/kusitms/samsion/common/config/CachingConfig.java
+++ b/src/main/java/com/kusitms/samsion/common/config/CachingConfig.java
@@ -1,0 +1,29 @@
+package com.kusitms.samsion.common.config;
+
+import java.time.Duration;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class CachingConfig {
+
+	@Bean
+	public CacheManager cacheManager(RedisConnectionFactory connectionFactory){
+		RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+			.entryTtl(Duration.ofMinutes(3L));
+		return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(connectionFactory).cacheDefaults(redisCacheConfiguration).build();
+	}
+}

--- a/src/main/java/com/kusitms/samsion/common/consts/CachingStoreConst.java
+++ b/src/main/java/com/kusitms/samsion/common/consts/CachingStoreConst.java
@@ -1,0 +1,16 @@
+package com.kusitms.samsion.common.consts;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CachingStoreConst {
+
+	public static final String ALBUM_LIST_CACHE_NAME = "albumList";
+	public static final String ALBUM_CACHE_NAME = "album";
+	public static final String COMMENT_CACHE_NAME = "comment";
+	public static final String COMMENT_COUNT_CACHE_NAME = "commentCount";
+	public static final String EMPATHY_CACHE_NAME = "empathy";
+	public static final String EMPATHY_COUNT_CACHE_NAME = "empathyCount";
+
+}

--- a/src/main/java/com/kusitms/samsion/common/domain/BaseEntity.java
+++ b/src/main/java/com/kusitms/samsion/common/domain/BaseEntity.java
@@ -9,6 +9,9 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import lombok.Getter;
+
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
@@ -19,11 +22,4 @@ public abstract class BaseEntity {
 	@LastModifiedDate
 	private LocalDateTime modifiedDate;
 
-	public LocalDateTime getCreatedDate() {
-		return createdDate;
-	}
-
-	public LocalDateTime getModifiedDate() {
-		return modifiedDate;
-	}
 }

--- a/src/main/java/com/kusitms/samsion/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/kusitms/samsion/common/exception/handler/GlobalExceptionHandler.java
@@ -8,12 +8,16 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.kusitms.samsion.common.exception.BusinessException;
 import com.kusitms.samsion.common.exception.dto.ErrorResponse;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler(BusinessException.class)
 	public ResponseEntity<ErrorResponse> handleJwtException(BusinessException e) {
 		final ErrorResponse errorResponse = ErrorResponse.from(e);
+		log.info("error log = {} {}",e.getError().getErrorCode(), e.getError().getMessage() );
 		return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
 	}
 }

--- a/src/main/java/com/kusitms/samsion/common/infrastructure/redis/RedisConfig.java
+++ b/src/main/java/com/kusitms/samsion/common/infrastructure/redis/RedisConfig.java
@@ -7,6 +7,11 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 @Configuration
 public class RedisConfig {
 
@@ -29,5 +34,12 @@ public class RedisConfig {
 		RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
 		redisTemplate.setConnectionFactory(redisConnectionFactory());
 		return redisTemplate;
+	}
+
+	@Bean public ObjectMapper objectMapper() {
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // timestamp 형식 안따르도록 설정
+		mapper.registerModules(new JavaTimeModule(), new Jdk8Module()); // LocalDateTime 매핑을 위해 모듈 활성화
+		return mapper;
 	}
 }

--- a/src/main/java/com/kusitms/samsion/domain/album/application/dto/response/AlbumInfoResponse.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/application/dto/response/AlbumInfoResponse.java
@@ -4,27 +4,28 @@ import java.util.List;
 
 import com.kusitms.samsion.domain.album.domain.entity.EmotionTag;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
- * TODO : 공감, 댓글, 이미지 정보도 같이 가져와야 함
+ * dto 캐싱할려면 기본생성자 만들어야함
  */
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AlbumInfoResponse {
 
-	private final List<String> imageUrlList;
-	private final String title;
-	private final String description;
+	private List<String> imageUrlList;
+	private String title;
+	private String description;
 
-	private final String writer;
-	private final String petName;
-	private final String writerProfileImageUrl;
-
-	private final long commentCount;
-	private final long empathyCount;
-
-	private final List<EmotionTag> emotionTagList;
+	private String writer;
+	private String petName;
+	private String writerProfileImageUrl;
+	private long commentCount;
+	private long empathyCount;
+	private List<EmotionTag> emotionTagList;
 
 	@Builder
 	public AlbumInfoResponse(List<String> imageUrlList, String title, String description, String writer, String petName, String writerProfileImageUrl,

--- a/src/main/java/com/kusitms/samsion/domain/album/presentation/AlbumController.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/presentation/AlbumController.java
@@ -1,5 +1,7 @@
 package com.kusitms.samsion.domain.album.presentation;
 
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -8,6 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kusitms.samsion.common.consts.CachingStoreConst;
 import com.kusitms.samsion.common.slice.SliceResponse;
 import com.kusitms.samsion.domain.album.application.dto.request.AlbumCreateRequest;
 import com.kusitms.samsion.domain.album.application.dto.request.AlbumSearchRequest;
@@ -56,6 +59,11 @@ public class AlbumController {
 		return albumCreateUseCase.createAlbum(request);
 	}
 
+	/**
+	 * 캐시 미적용 : 3회 warmup 4회 테스트 평균 40ms
+	 * 캐시 적용 : 3회 warmup 4회 테스트 평균 20ms
+	 */
+	@Cacheable(value = CachingStoreConst.ALBUM_CACHE_NAME, key = "#albumId")
 	@GetMapping("/{albumId}")
 	public AlbumInfoResponse getAlbum(@PathVariable Long albumId){
 		return albumReadUseCase.getAlbum(albumId);
@@ -64,6 +72,7 @@ public class AlbumController {
 	/**
 	 * 앨범 수정, 삭제 기능 추가해야함
 	 */
+	@CacheEvict(value = CachingStoreConst.ALBUM_CACHE_NAME, key = "#albumId")
 	@PostMapping("/{albumId}")
 	public void updateAlbum(@PathVariable Long albumId, @ModelAttribute AlbumUpdateRequest request){
 		albumUpdateUseCase.updateAlbum(albumId, request);

--- a/src/main/java/com/kusitms/samsion/domain/album/presentation/AlbumController.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/presentation/AlbumController.java
@@ -38,6 +38,9 @@ public class AlbumController {
 	/**
 	 * 기존 jpa : 앨범 10개 조회 기준, 3회 warmup, 4회 테스트 평균 853ms
 	 * QueryDsl : 앨범 10개 조회 기준, 3회 warmup, 4회 테스트 평균 347ms
+	 *
+	 * 캐시 미적용 : 3회 warmup 4회 테스트 평균 200ms
+	 * 캐시 적용(댓글, 공감 수 캐싱) : 3회 warmup 4회 테스트 평균 150ms
 	 */
 	@GetMapping
 	public SliceResponse<AlbumSimpleResponse> getAlbumList(Pageable pageable, @ModelAttribute AlbumSearchRequest request){

--- a/src/main/java/com/kusitms/samsion/domain/comment/domain/service/CommentDeleteService.java
+++ b/src/main/java/com/kusitms/samsion/domain/comment/domain/service/CommentDeleteService.java
@@ -1,11 +1,9 @@
 package com.kusitms.samsion.domain.comment.domain.service;
 
-import org.springframework.cache.annotation.CacheEvict;
-
 import com.kusitms.samsion.common.annotation.DomainService;
-import com.kusitms.samsion.common.consts.CachingStoreConst;
 import com.kusitms.samsion.domain.comment.domain.entity.Comment;
 import com.kusitms.samsion.domain.comment.domain.repository.CommentRepository;
+
 import lombok.RequiredArgsConstructor;
 
 @DomainService
@@ -14,7 +12,6 @@ public class CommentDeleteService {
 
     private final CommentRepository commentRepository;
 
-    @CacheEvict(value = CachingStoreConst.COMMENT_COUNT_CACHE_NAME, key = "#comment.albumId")
     public void deleteComment(Comment comment) {
 
         commentRepository.deleteById(comment.getId());

--- a/src/main/java/com/kusitms/samsion/domain/comment/domain/service/CommentDeleteService.java
+++ b/src/main/java/com/kusitms/samsion/domain/comment/domain/service/CommentDeleteService.java
@@ -1,6 +1,9 @@
 package com.kusitms.samsion.domain.comment.domain.service;
 
+import org.springframework.cache.annotation.CacheEvict;
+
 import com.kusitms.samsion.common.annotation.DomainService;
+import com.kusitms.samsion.common.consts.CachingStoreConst;
 import com.kusitms.samsion.domain.comment.domain.entity.Comment;
 import com.kusitms.samsion.domain.comment.domain.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +14,7 @@ public class CommentDeleteService {
 
     private final CommentRepository commentRepository;
 
+    @CacheEvict(value = CachingStoreConst.COMMENT_COUNT_CACHE_NAME, key = "#comment.albumId")
     public void deleteComment(Comment comment) {
 
         commentRepository.deleteById(comment.getId());

--- a/src/main/java/com/kusitms/samsion/domain/comment/domain/service/CommentQueryService.java
+++ b/src/main/java/com/kusitms/samsion/domain/comment/domain/service/CommentQueryService.java
@@ -1,15 +1,19 @@
 package com.kusitms.samsion.domain.comment.domain.service;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.kusitms.samsion.common.annotation.DomainService;
 import com.kusitms.samsion.common.exception.Error;
 import com.kusitms.samsion.domain.comment.domain.entity.Comment;
 import com.kusitms.samsion.domain.comment.domain.exception.CommentNotFoundException;
 import com.kusitms.samsion.domain.comment.domain.repository.CommentRepository;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 
 @DomainService
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class CommentQueryService {
 

--- a/src/main/java/com/kusitms/samsion/domain/comment/domain/service/CommentQueryService.java
+++ b/src/main/java/com/kusitms/samsion/domain/comment/domain/service/CommentQueryService.java
@@ -1,10 +1,12 @@
 package com.kusitms.samsion.domain.comment.domain.service;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kusitms.samsion.common.annotation.DomainService;
+import com.kusitms.samsion.common.consts.CachingStoreConst;
 import com.kusitms.samsion.common.exception.Error;
 import com.kusitms.samsion.domain.comment.domain.entity.Comment;
 import com.kusitms.samsion.domain.comment.domain.exception.CommentNotFoundException;
@@ -27,7 +29,7 @@ public class CommentQueryService {
         return commentRepository.findByAlbumId(pageable, albumId);
     }
 
-
+    @Cacheable(value = CachingStoreConst.COMMENT_COUNT_CACHE_NAME, key = "#albumId")
     public long getCommentCountByAlbumId(Long albumId){
         return commentRepository.countByAlbumId(albumId);
     }

--- a/src/main/java/com/kusitms/samsion/domain/comment/domain/service/CommentSaveService.java
+++ b/src/main/java/com/kusitms/samsion/domain/comment/domain/service/CommentSaveService.java
@@ -1,11 +1,9 @@
 package com.kusitms.samsion.domain.comment.domain.service;
 
-import org.springframework.cache.annotation.CacheEvict;
-
 import com.kusitms.samsion.common.annotation.DomainService;
-import com.kusitms.samsion.common.consts.CachingStoreConst;
 import com.kusitms.samsion.domain.comment.domain.entity.Comment;
 import com.kusitms.samsion.domain.comment.domain.repository.CommentRepository;
+
 import lombok.RequiredArgsConstructor;
 
 @DomainService
@@ -14,7 +12,6 @@ public class CommentSaveService {
 
     private final CommentRepository commentRepository;
 
-    @CacheEvict(value = CachingStoreConst.COMMENT_COUNT_CACHE_NAME, key = "#comment.albumId")
     public void saveComment(Comment comment) {
 
         commentRepository.save(comment);

--- a/src/main/java/com/kusitms/samsion/domain/comment/domain/service/CommentSaveService.java
+++ b/src/main/java/com/kusitms/samsion/domain/comment/domain/service/CommentSaveService.java
@@ -1,6 +1,9 @@
 package com.kusitms.samsion.domain.comment.domain.service;
 
+import org.springframework.cache.annotation.CacheEvict;
+
 import com.kusitms.samsion.common.annotation.DomainService;
+import com.kusitms.samsion.common.consts.CachingStoreConst;
 import com.kusitms.samsion.domain.comment.domain.entity.Comment;
 import com.kusitms.samsion.domain.comment.domain.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +14,7 @@ public class CommentSaveService {
 
     private final CommentRepository commentRepository;
 
+    @CacheEvict(value = CachingStoreConst.COMMENT_COUNT_CACHE_NAME, key = "#comment.albumId")
     public void saveComment(Comment comment) {
 
         commentRepository.save(comment);

--- a/src/main/java/com/kusitms/samsion/domain/comment/presentation/CommentController.java
+++ b/src/main/java/com/kusitms/samsion/domain/comment/presentation/CommentController.java
@@ -1,5 +1,17 @@
 package com.kusitms.samsion.domain.comment.presentation;
 
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kusitms.samsion.common.consts.CachingStoreConst;
 import com.kusitms.samsion.common.slice.SliceResponse;
 import com.kusitms.samsion.domain.comment.application.dto.request.CommentCreateRequest;
 import com.kusitms.samsion.domain.comment.application.dto.request.CommentUpdateRequest;
@@ -8,9 +20,8 @@ import com.kusitms.samsion.domain.comment.application.service.CommentCreateUseCa
 import com.kusitms.samsion.domain.comment.application.service.CommentDeleteUseCase;
 import com.kusitms.samsion.domain.comment.application.service.CommentReadUseCase;
 import com.kusitms.samsion.domain.comment.application.service.CommentUpdateUseCase;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/album")
@@ -33,11 +44,13 @@ public class CommentController {
         return commentCreateUseCase.createReComment(albumId, commentId, commentCreateRequest);
     }
 
+    @CacheEvict(value = CachingStoreConst.COMMENT_COUNT_CACHE_NAME, key = "#comment.albumId")
     @PutMapping("/comment/{commentId}")
     public CommentInfoResponse update(@PathVariable Long commentId, @RequestBody CommentUpdateRequest commentUpdateRequest){
         return commentUpdateUseCase.updateComment(commentId, commentUpdateRequest);
     }
 
+    @CacheEvict(value = CachingStoreConst.COMMENT_COUNT_CACHE_NAME, key = "#comment.albumId")
     @DeleteMapping("/comment/{commentId}")
     public void delete(@PathVariable Long commentId){
         commentDeleteUseCase.deleteComment(commentId);

--- a/src/main/java/com/kusitms/samsion/domain/empathy/domain/service/EmpathyDeleteService.java
+++ b/src/main/java/com/kusitms/samsion/domain/empathy/domain/service/EmpathyDeleteService.java
@@ -1,8 +1,10 @@
 package com.kusitms.samsion.domain.empathy.domain.service;
 
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kusitms.samsion.common.annotation.DomainService;
+import com.kusitms.samsion.common.consts.CachingStoreConst;
 import com.kusitms.samsion.domain.empathy.domain.repository.EmpathyRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,7 @@ public class EmpathyDeleteService {
 
 	private final EmpathyRepository empathyRepository;
 
+	@CacheEvict(value = CachingStoreConst.EMPATHY_COUNT_CACHE_NAME, key = "#comment.albumId")
 	public void deleteEmpathy(Long userId, Long albumId){
 		empathyRepository.deleteByUserIdAndAlbumId(userId, albumId);
 	}

--- a/src/main/java/com/kusitms/samsion/domain/empathy/domain/service/EmpathyDeleteService.java
+++ b/src/main/java/com/kusitms/samsion/domain/empathy/domain/service/EmpathyDeleteService.java
@@ -1,10 +1,8 @@
 package com.kusitms.samsion.domain.empathy.domain.service;
 
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kusitms.samsion.common.annotation.DomainService;
-import com.kusitms.samsion.common.consts.CachingStoreConst;
 import com.kusitms.samsion.domain.empathy.domain.repository.EmpathyRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -16,7 +14,6 @@ public class EmpathyDeleteService {
 
 	private final EmpathyRepository empathyRepository;
 
-	@CacheEvict(value = CachingStoreConst.EMPATHY_COUNT_CACHE_NAME, key = "#comment.albumId")
 	public void deleteEmpathy(Long userId, Long albumId){
 		empathyRepository.deleteByUserIdAndAlbumId(userId, albumId);
 	}

--- a/src/main/java/com/kusitms/samsion/domain/empathy/domain/service/EmpathyQueryService.java
+++ b/src/main/java/com/kusitms/samsion/domain/empathy/domain/service/EmpathyQueryService.java
@@ -1,8 +1,10 @@
 package com.kusitms.samsion.domain.empathy.domain.service;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kusitms.samsion.common.annotation.DomainService;
+import com.kusitms.samsion.common.consts.CachingStoreConst;
 import com.kusitms.samsion.domain.empathy.domain.repository.EmpathyRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,8 @@ public class EmpathyQueryService {
 		return empathyRepository.existsByUserIdAndAlbumId(userId, albumId);
 	}
 
+
+	@Cacheable(value = CachingStoreConst.EMPATHY_COUNT_CACHE_NAME, key = "#albumId")
 	public long getEmpathyCountByAlbumId(Long albumId){
 		return empathyRepository.countByAlbumId(albumId);
 	}

--- a/src/main/java/com/kusitms/samsion/domain/empathy/domain/service/EmpathySaveService.java
+++ b/src/main/java/com/kusitms/samsion/domain/empathy/domain/service/EmpathySaveService.java
@@ -1,10 +1,8 @@
 package com.kusitms.samsion.domain.empathy.domain.service;
 
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kusitms.samsion.common.annotation.DomainService;
-import com.kusitms.samsion.common.consts.CachingStoreConst;
 import com.kusitms.samsion.domain.album.domain.entity.Album;
 import com.kusitms.samsion.domain.empathy.domain.entity.Empathy;
 import com.kusitms.samsion.domain.empathy.domain.repository.EmpathyRepository;
@@ -19,7 +17,7 @@ public class EmpathySaveService {
 
 	private final EmpathyRepository empathyRepository;
 
-	@CacheEvict(value = CachingStoreConst.EMPATHY_COUNT_CACHE_NAME, key = "#comment.albumId")
+
 	public void saveEmpathy(User user, Album album){
 		final Empathy empathy = new Empathy(user, album);
 		empathyRepository.save(empathy);

--- a/src/main/java/com/kusitms/samsion/domain/empathy/domain/service/EmpathySaveService.java
+++ b/src/main/java/com/kusitms/samsion/domain/empathy/domain/service/EmpathySaveService.java
@@ -1,8 +1,10 @@
 package com.kusitms.samsion.domain.empathy.domain.service;
 
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kusitms.samsion.common.annotation.DomainService;
+import com.kusitms.samsion.common.consts.CachingStoreConst;
 import com.kusitms.samsion.domain.album.domain.entity.Album;
 import com.kusitms.samsion.domain.empathy.domain.entity.Empathy;
 import com.kusitms.samsion.domain.empathy.domain.repository.EmpathyRepository;
@@ -17,6 +19,7 @@ public class EmpathySaveService {
 
 	private final EmpathyRepository empathyRepository;
 
+	@CacheEvict(value = CachingStoreConst.EMPATHY_COUNT_CACHE_NAME, key = "#comment.albumId")
 	public void saveEmpathy(User user, Album album){
 		final Empathy empathy = new Empathy(user, album);
 		empathyRepository.save(empathy);

--- a/src/main/java/com/kusitms/samsion/domain/empathy/presentation/EmpathyController.java
+++ b/src/main/java/com/kusitms/samsion/domain/empathy/presentation/EmpathyController.java
@@ -1,9 +1,11 @@
 package com.kusitms.samsion.domain.empathy.presentation;
 
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kusitms.samsion.common.consts.CachingStoreConst;
 import com.kusitms.samsion.domain.empathy.application.service.EmpathyToggleUseCase;
 
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,7 @@ public class EmpathyController {
 
 	private final EmpathyToggleUseCase empathyToggleUseCase;
 
+	@CacheEvict(value = CachingStoreConst.EMPATHY_COUNT_CACHE_NAME, key = "#comment.albumId")
 	@GetMapping("/album/{albumId}/empathy")
 	public void addEmpathy(@PathVariable Long albumId) {
 		empathyToggleUseCase.toggleEmpathy(albumId);


### PR DESCRIPTION
# Summary

---

* 캐싱 설정 추가
* 앨범 조회시 캐싱하도록함
* 앨범 수정하면 캐싱한 데이터 삭제
* comment query 서비스에 읽기전용 트랜잭션 애노테이션 추가
* 댓글 카운트 수 캐싱, 댓글 수정, 삭제시 캐시 데이터 삭제
* 공감 카운트 수 캐싱, 공감 추가, 삭제 시  캐시 데이터 삭제

# Issue

---


# References

---

* https://pamyferret.tistory.com/8
* https://mangchhe.github.io/springboot/2021/09/15/SpringBootCache/

