### PR TITLE
[feat] UseCase 테스트 @DisplayName 수정 및 캐싱 데이터 제거 트리거 수정

### DIFF
--- a/src/main/java/com/kusitms/samsion/domain/album/application/service/AlbumUpdateUseCase.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/application/service/AlbumUpdateUseCase.java
@@ -4,19 +4,16 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kusitms.samsion.common.annotation.UseCase;
-import com.kusitms.samsion.common.infrastructure.s3.S3UploadService;
 import com.kusitms.samsion.common.util.UserUtils;
 import com.kusitms.samsion.domain.album.application.dto.request.AlbumImageUpdateRequest;
 import com.kusitms.samsion.domain.album.application.dto.request.AlbumUpdateRequest;
 import com.kusitms.samsion.domain.album.application.dto.request.TagUpdateRequest;
 import com.kusitms.samsion.domain.album.domain.entity.Album;
 import com.kusitms.samsion.domain.album.domain.service.AlbumImageDeleteService;
-import com.kusitms.samsion.domain.album.domain.service.AlbumImageUpdateService;
 import com.kusitms.samsion.domain.album.domain.service.AlbumQueryService;
 import com.kusitms.samsion.domain.album.domain.service.AlbumUpdateService;
 import com.kusitms.samsion.domain.album.domain.service.AlbumValidAccessService;
 import com.kusitms.samsion.domain.album.domain.service.TagDeleteService;
-import com.kusitms.samsion.domain.album.domain.service.TagUpdateService;
 import com.kusitms.samsion.domain.user.domain.entity.User;
 
 import lombok.RequiredArgsConstructor;
@@ -32,10 +29,7 @@ public class AlbumUpdateUseCase {
 	private final AlbumQueryService albumQueryService;
 	private final AlbumValidAccessService albumValidAccessService;
 	private final AlbumUpdateService albumUpdateService;
-	private final S3UploadService s3UploadService;
-	private final AlbumImageUpdateService albumImageUpdateService;
 	private final AlbumImageDeleteService albumImageDeleteService;
-	private final TagUpdateService tagUpdateService;
 	private final TagDeleteService tagDeleteService;
 
 	private final ApplicationEventPublisher applicationEventPublisher;
@@ -47,12 +41,9 @@ public class AlbumUpdateUseCase {
 		final User user = userUtils.getUser();
 		final Album album = albumQueryService.findAlbumById(albumId);
 		albumValidAccessService.validateAccess(album, user.getId());
-
 		albumUpdateService.updateAlbum(album, request.getTitle(), request.getDescription(), request.getVisibility());
-
 		albumImageDeleteService.deleteAlbumImageList(album);
 		tagDeleteService.deleteTagList(album);
-
 		applicationEventPublisher.publishEvent(new AlbumImageUpdateRequest(album.getId(), request.getImageUrlList(),request.getAddImageList()));
 		applicationEventPublisher.publishEvent(new TagUpdateRequest(album.getId(), request.getEmotionTagList()));
 	}

--- a/src/main/java/com/kusitms/samsion/domain/comment/presentation/CommentController.java
+++ b/src/main/java/com/kusitms/samsion/domain/comment/presentation/CommentController.java
@@ -33,24 +33,25 @@ public class CommentController {
     private final CommentDeleteUseCase commentDeleteUseCase;
     private final CommentReadUseCase commentReadUseCase;
 
+    @CacheEvict(value = CachingStoreConst.COMMENT_COUNT_CACHE_NAME, key = "#albumId")
     @PostMapping("/{albumId}/comment")
     public CommentInfoResponse createComment(@PathVariable Long albumId, @RequestBody CommentCreateRequest commentCreateRequest) {
         return commentCreateUseCase.createComment(albumId, commentCreateRequest);
     }
 
+    @CacheEvict(value = CachingStoreConst.COMMENT_COUNT_CACHE_NAME, key = "#albumId")
     @PostMapping("/{albumId}/comment/{commentId}")
     public CommentInfoResponse createReComment(@PathVariable Long albumId, @PathVariable Long commentId,
                                                @RequestBody CommentCreateRequest commentCreateRequest) {
         return commentCreateUseCase.createReComment(albumId, commentId, commentCreateRequest);
     }
 
-    @CacheEvict(value = CachingStoreConst.COMMENT_COUNT_CACHE_NAME, key = "#comment.albumId")
     @PutMapping("/{albumId}/comment/{commentId}")
     public CommentInfoResponse update(@PathVariable Long commentId, @RequestBody CommentUpdateRequest commentUpdateRequest){
         return commentUpdateUseCase.updateComment(commentId, commentUpdateRequest);
     }
 
-    @CacheEvict(value = CachingStoreConst.COMMENT_COUNT_CACHE_NAME, key = "#comment.albumId")
+    @CacheEvict(value = CachingStoreConst.COMMENT_COUNT_CACHE_NAME, key = "#albumId")
     @DeleteMapping("/{albumId}/comment/{commentId}")
     public void delete(@PathVariable Long commentId){
         commentDeleteUseCase.deleteComment(commentId);

--- a/src/main/java/com/kusitms/samsion/domain/empathy/presentation/EmpathyController.java
+++ b/src/main/java/com/kusitms/samsion/domain/empathy/presentation/EmpathyController.java
@@ -16,7 +16,7 @@ public class EmpathyController {
 
 	private final EmpathyToggleUseCase empathyToggleUseCase;
 
-	@CacheEvict(value = CachingStoreConst.EMPATHY_COUNT_CACHE_NAME, key = "#comment.albumId")
+	@CacheEvict(value = CachingStoreConst.EMPATHY_COUNT_CACHE_NAME, key = "#albumId")
 	@GetMapping("/album/{albumId}/empathy")
 	public void addEmpathy(@PathVariable Long albumId) {
 		empathyToggleUseCase.toggleEmpathy(albumId);

--- a/src/test/java/com/kusitms/samsion/domain/empathy/application/service/EmpathyToggleUseCaseTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/empathy/application/service/EmpathyToggleUseCaseTest.java
@@ -21,7 +21,7 @@ import com.kusitms.samsion.domain.empathy.domain.service.EmpathySaveService;
 import com.kusitms.samsion.domain.user.domain.entity.User;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("EmpathyToggleService 테스트")
+@DisplayName("EmpathyToggleUsecase 테스트")
 class EmpathyToggleUseCaseTest {
 
 	@Mock

--- a/src/test/java/com/kusitms/samsion/domain/question/application/service/AnswerCreateUseCaseTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/question/application/service/AnswerCreateUseCaseTest.java
@@ -20,7 +20,7 @@ import com.kusitms.samsion.domain.question.domain.service.QuestionQueryService;
 import com.kusitms.samsion.domain.user.domain.entity.User;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("AnswerCreateService 테스트")
+@DisplayName("AnswerCreateUseCase 테스트")
 class AnswerCreateUseCaseTest {
 
 	@Mock

--- a/src/test/java/com/kusitms/samsion/domain/question/application/service/AnswerUpdateUseCaseTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/question/application/service/AnswerUpdateUseCaseTest.java
@@ -20,7 +20,7 @@ import com.kusitms.samsion.domain.question.domain.service.AnswerQueryService;
 import com.kusitms.samsion.domain.user.domain.entity.User;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("AnswerUpdateService 테스트")
+@DisplayName("AnswerUpdateUseCase 테스트")
 class AnswerUpdateUseCaseTest {
 
 	@Mock

--- a/src/test/java/com/kusitms/samsion/domain/question/application/service/QuestionReadUseCaseTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/question/application/service/QuestionReadUseCaseTest.java
@@ -30,7 +30,7 @@ import com.kusitms.samsion.domain.question.domain.service.QuestionQueryService;
 import com.kusitms.samsion.domain.user.domain.entity.User;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("QuestionReadService 테스트")
+@DisplayName("QuestionReadUseCase 테스트")
 class QuestionReadUseCaseTest {
 
 	@Mock

--- a/src/test/java/com/kusitms/samsion/domain/user/application/service/MyPetInfoUseCaseTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/user/application/service/MyPetInfoUseCaseTest.java
@@ -17,7 +17,7 @@ import com.kusitms.samsion.domain.user.domain.entity.MyPet;
 import com.kusitms.samsion.domain.user.domain.entity.User;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("MyPetInfoService 테스트")
+@DisplayName("MyPetInfoUseCase 테스트")
 class MyPetInfoUseCaseTest {
 
 	@Mock

--- a/src/test/java/com/kusitms/samsion/domain/user/application/service/MyPetUpdateUseCaseTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/user/application/service/MyPetUpdateUseCaseTest.java
@@ -19,7 +19,7 @@ import com.kusitms.samsion.domain.user.domain.entity.User;
 import com.kusitms.samsion.common.infrastructure.s3.S3UploadService;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("MyPetUpdateService 테스트")
+@DisplayName("MyPetUpdateUseCase 테스트")
 class MyPetUpdateUseCaseTest {
 
 	@Mock


### PR DESCRIPTION
# Summary

---

* UseCase 테스트에서 @DisplayName에 service->usecase로 수정
* 댓글 캐싱 데이터 제거는 댓글, 대댓글 생성, 삭제시 같이 제거
* AlbumUpdateUseCase 의존성 정리


# Issue

---


# References

---


