### PR TITLE
[test] Album Application 계층 UseCase, Handler 테스트 작성

### DIFF
--- a/src/main/java/com/kusitms/samsion/domain/album/application/service/AlbumReadUseCase.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/application/service/AlbumReadUseCase.java
@@ -42,14 +42,14 @@ public class AlbumReadUseCase {
 	 */
 	public SliceResponse<AlbumSimpleResponse> getAlbumList(Pageable pageable, AlbumSearchRequest request){
 
-		Slice<Album> albumList = albumQueryService.getAlbumList(pageable,request.getEmotionTagList(), request.getSortType());
+		Slice<Album> albumList = albumQueryService.findAlbumList(pageable,request.getEmotionTagList(), request.getSortType());
 
 		return getSliceResponseAboutAlbumSimpleResponse(albumList);
 	}
 
 	public SliceResponse<AlbumSimpleResponse> getMyAlbumList(Pageable pageable, AlbumSearchRequest request){
 		Slice<Album> myAlbumList =
-			albumQueryService.getMyAlbumList(pageable, request.getEmotionTagList(), request.getSortType(), userUtils.getUser().getId());
+			albumQueryService.findMyAlbumList(pageable, request.getEmotionTagList(), request.getSortType(), userUtils.getUser().getId());
 
 		return getSliceResponseAboutAlbumSimpleResponse(myAlbumList);
 	}

--- a/src/main/java/com/kusitms/samsion/domain/album/domain/entity/Album.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/domain/entity/Album.java
@@ -114,12 +114,10 @@ public class Album extends BaseEntity {
 	}
 
 	public void clearAllImage(){
-		this.albumImages.clear();
-		// this.albumImages= new ArrayList<>();
+		this.albumImages= new ArrayList<>();
 	}
 
 	public void clearAllTag() {
-		this.tags.clear();
-		// this.tags = new ArrayList<>();
+		this.tags = new ArrayList<>();
 	}
 }

--- a/src/main/java/com/kusitms/samsion/domain/album/domain/service/AlbumQueryService.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/domain/service/AlbumQueryService.java
@@ -25,11 +25,11 @@ public class AlbumQueryService {
 		return albumRepository.findById(albumId).orElseThrow(() -> new AlbumNotFoundException(Error.ALBUM_NOT_FOUND));
 	}
 
-	public Slice<Album> getAlbumList(Pageable pageable, List<EmotionTag> emotionTagList, SortType sortType){
+	public Slice<Album> findAlbumList(Pageable pageable, List<EmotionTag> emotionTagList, SortType sortType){
 		return albumRepository.findAlbumList(pageable, emotionTagList, sortType);
 	}
 
-	public Slice<Album> getMyAlbumList(Pageable pageable, List<EmotionTag> emotionTagList, SortType sortType, Long userId){
+	public Slice<Album> findMyAlbumList(Pageable pageable, List<EmotionTag> emotionTagList, SortType sortType, Long userId){
 		return albumRepository.findMyAlbumList(pageable, emotionTagList, sortType, userId);
 	}
 

--- a/src/test/java/com/kusitms/samsion/common/consts/TestConst.java
+++ b/src/test/java/com/kusitms/samsion/common/consts/TestConst.java
@@ -1,7 +1,12 @@
 package com.kusitms.samsion.common.consts;
 
+import java.util.List;
+
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
+
+import com.kusitms.samsion.domain.album.domain.entity.EmotionTag;
+import com.kusitms.samsion.domain.album.domain.entity.SortType;
 
 public class TestConst {
 
@@ -47,6 +52,7 @@ public class TestConst {
 	public static final String TEST_UPDATE_ALBUM_TITLE = "testUpdateAlbumTitle";
 	public static final String TEST_UPDATE_ALBUM_DESCRIPTION = "testUpdateAlbumDescription";
 	public static final String TEST_UPDATE_ALBUM_IMAGE_URL = "testUpdateAlbumImageUrl";
+	public static final SortType TEST_SORT_TYPE = SortType.DEFAULT;
 
 	// 댓글
 	public static final Long TEST_COMMENT_ID = 1L;
@@ -82,4 +88,12 @@ public class TestConst {
 	public static final String TEST_PHONENUMBER = "1588-4377";
 
 	public static final String TEST_URL = "shopurl";
+
+
+	// 태그
+	public static final List<EmotionTag> EMOTION_TAG_LIST = List.of(EmotionTag.COMFORTABLE);
+	public static final Long TEST_TAG_ID = 1L;
+
+	// 앨범 이미지
+	public static final Long TEST_ALBUM_IMAGE_ID = 1L;
 }

--- a/src/test/java/com/kusitms/samsion/common/util/AlbumTestUtils.java
+++ b/src/test/java/com/kusitms/samsion/common/util/AlbumTestUtils.java
@@ -1,21 +1,44 @@
 package com.kusitms.samsion.common.util;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.kusitms.samsion.common.consts.TestConst;
 import com.kusitms.samsion.domain.album.domain.entity.Album;
+import com.kusitms.samsion.domain.album.domain.entity.AlbumImage;
+import com.kusitms.samsion.domain.album.domain.entity.Tag;
 import com.kusitms.samsion.domain.album.domain.entity.Visibility;
 import com.kusitms.samsion.domain.user.domain.entity.User;
 
 public class AlbumTestUtils {
 
-    public static Album getMockAlbum(User mockUser) {
-        Album mockAlbum = Album.builder()
-                .writer(mockUser)
-                .visibility(Visibility.PUBLIC)
-                .description(TestConst.TEST_DESCRIPTION)
-                .build();
-        ReflectionTestUtils.setField(mockAlbum, "id", TestConst.TEST_ALBUM_ID);
-        return mockAlbum;
-    }
+	public static Album getMockAlbum(User mockUser) {
+		Album mockAlbum = Album.builder()
+			.writer(mockUser)
+			.title(TestConst.TEST_ALBUM_TITLE)
+			.visibility(Visibility.PUBLIC)
+			.description(TestConst.TEST_DESCRIPTION)
+			.build();
+		ReflectionTestUtils.setField(mockAlbum, "id", TestConst.TEST_ALBUM_ID);
+
+		mockAlbum.changeAllImage(getMockAlbumImageList(mockAlbum));
+		mockAlbum.changeAllTag(getMockTagList(mockAlbum));
+		return mockAlbum;
+	}
+
+	private static List<AlbumImage> getMockAlbumImageList(Album mockAlbum) {
+		AlbumImage albumImage = new AlbumImage(TestConst.TEST_ALBUM_IMAGE_URL, mockAlbum);
+		ReflectionTestUtils.setField(albumImage, "id", TestConst.TEST_ALBUM_IMAGE_ID);
+		return List.of(albumImage);
+	}
+
+	private static List<Tag> getMockTagList(Album mockAlbum) {
+		List<Tag> tagList = TestConst.EMOTION_TAG_LIST.stream()
+			.map(tag -> new Tag(tag, mockAlbum))
+			.collect(Collectors.toList());
+		tagList.forEach(tag -> ReflectionTestUtils.setField(tag, "id", TestConst.TEST_TAG_ID));
+		return tagList;
+	}
 }

--- a/src/test/java/com/kusitms/samsion/domain/album/application/handler/AlbumImageUpdateHandlerTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/album/application/handler/AlbumImageUpdateHandlerTest.java
@@ -1,0 +1,70 @@
+package com.kusitms.samsion.domain.album.application.handler;
+
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.kusitms.samsion.common.consts.TestConst;
+import com.kusitms.samsion.common.infrastructure.s3.S3UploadService;
+import com.kusitms.samsion.common.util.AlbumTestUtils;
+import com.kusitms.samsion.common.util.UserTestUtils;
+import com.kusitms.samsion.domain.album.application.dto.request.AlbumImageUpdateRequest;
+import com.kusitms.samsion.domain.album.domain.entity.Album;
+import com.kusitms.samsion.domain.album.domain.entity.AlbumImage;
+import com.kusitms.samsion.domain.album.domain.service.AlbumImageUpdateService;
+import com.kusitms.samsion.domain.album.domain.service.AlbumQueryService;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AlbumImageUpdateHandler 테스트")
+class AlbumImageUpdateHandlerTest {
+
+	@Mock
+	AlbumQueryService albumQueryService;
+	@Mock
+	AlbumImageUpdateService albumImageUpdateService;
+	@Mock
+	S3UploadService s3UploadService;
+
+	AlbumImageUpdateHandler albumImageUpdateHandler;
+
+	@BeforeEach
+	void setUp() {
+		albumImageUpdateHandler = new AlbumImageUpdateHandler(albumQueryService, albumImageUpdateService,
+			s3UploadService);
+	}
+
+	@Test
+	void 앨범_이미지를_업데이트한다() {
+		//given
+		User mockUser = UserTestUtils.getMockUser();
+		Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+		mockAlbum.clearAllImage();
+		AlbumImageUpdateRequest mockAlbumImageUpdateRequest = getMockAlbumImageUpdateRequest(mockAlbum.getId());
+		given(albumQueryService.findAlbumById(mockAlbum.getId())).willReturn(mockAlbum);
+		given(s3UploadService.uploadImgList(mockAlbumImageUpdateRequest.getAddImageList()))
+			.willReturn(List.of(TestConst.TEST_UPDATE_ALBUM_IMAGE_URL));
+		Stream.of(TestConst.TEST_UPDATE_ALBUM_IMAGE_URL, TestConst.TEST_ALBUM_IMAGE_URL)
+			.map(url -> new AlbumImage(url, mockAlbum)).collect(Collectors.toList());
+		//when
+		albumImageUpdateHandler.updateAlbumImage(mockAlbumImageUpdateRequest);
+		//then
+		then(albumImageUpdateService).should(times(1))
+			.updateAlbumImage(eq(mockAlbum), anyList());
+	}
+
+	AlbumImageUpdateRequest getMockAlbumImageUpdateRequest(Long albumId) {
+		return new AlbumImageUpdateRequest(albumId, List.of(TestConst.TEST_ALBUM_IMAGE_URL),
+			List.of(TestConst.TEST_MULTIPART_FILE));
+	}
+
+}

--- a/src/test/java/com/kusitms/samsion/domain/album/application/handler/TagUpdateHandlerTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/album/application/handler/TagUpdateHandlerTest.java
@@ -1,0 +1,54 @@
+package com.kusitms.samsion.domain.album.application.handler;
+
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.kusitms.samsion.common.consts.TestConst;
+import com.kusitms.samsion.common.util.AlbumTestUtils;
+import com.kusitms.samsion.common.util.UserTestUtils;
+import com.kusitms.samsion.domain.album.application.dto.request.TagUpdateRequest;
+import com.kusitms.samsion.domain.album.domain.entity.Album;
+import com.kusitms.samsion.domain.album.domain.service.AlbumQueryService;
+import com.kusitms.samsion.domain.album.domain.service.TagUpdateService;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TagUpdateHandler 테스트")
+class TagUpdateHandlerTest {
+
+	@Mock
+	AlbumQueryService albumQueryService;
+	@Mock
+	TagUpdateService tagUpdateService;
+
+	TagUpdateHandler tagUpdateHandler;
+
+	@BeforeEach
+	void setUp() {
+		tagUpdateHandler = new TagUpdateHandler(albumQueryService, tagUpdateService);
+	}
+
+	@Test
+	void 태그를_수정한다() {
+		//given
+		User mockUser = UserTestUtils.getMockUser();
+		Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+		mockAlbum.clearAllTag();
+		given(albumQueryService.findAlbumById(mockAlbum.getId())).willReturn(mockAlbum);
+		//when
+		tagUpdateHandler.updateTag(getMockTagUpdateRequest(mockAlbum.getId()));
+		//then
+		then(tagUpdateService).should(times(1))
+			.updateTag(eq(mockAlbum), eq(mockAlbum.getTags()));
+	}
+
+	TagUpdateRequest getMockTagUpdateRequest(Long mockAlbumId) {
+		return new TagUpdateRequest(mockAlbumId, TestConst.EMOTION_TAG_LIST);
+	}
+}

--- a/src/test/java/com/kusitms/samsion/domain/album/application/service/AlbumCreateUseCaseTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/album/application/service/AlbumCreateUseCaseTest.java
@@ -1,0 +1,94 @@
+package com.kusitms.samsion.domain.album.application.service;
+
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import com.kusitms.samsion.common.consts.TestConst;
+import com.kusitms.samsion.common.infrastructure.s3.S3UploadService;
+import com.kusitms.samsion.common.util.AlbumTestUtils;
+import com.kusitms.samsion.common.util.UserTestUtils;
+import com.kusitms.samsion.common.util.UserUtils;
+import com.kusitms.samsion.domain.album.application.dto.request.AlbumCreateRequest;
+import com.kusitms.samsion.domain.album.application.dto.response.AlbumInfoResponse;
+import com.kusitms.samsion.domain.album.domain.entity.Album;
+import com.kusitms.samsion.domain.album.domain.service.AlbumImageSaveService;
+import com.kusitms.samsion.domain.album.domain.service.AlbumSaveService;
+import com.kusitms.samsion.domain.album.domain.service.TagSaveService;
+import com.kusitms.samsion.domain.user.domain.entity.MyPet;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AlbumCreateUseCase 테스트")
+class AlbumCreateUseCaseTest {
+
+	@Mock
+	UserUtils userUtils;
+	@Mock
+	AlbumSaveService albumSaveService;
+	@Mock
+	AlbumImageSaveService albumImageSaveService;
+	@Mock
+	TagSaveService tagSaveService;
+	@Mock
+	S3UploadService s3UploadService;
+
+	@Mock
+	ApplicationEventPublisher applicationEventPublisher;
+
+	AlbumCreateUseCase albumCreateUseCase;
+
+	@BeforeEach
+	void setUp() {
+		albumCreateUseCase = new AlbumCreateUseCase(userUtils, albumSaveService, albumImageSaveService, tagSaveService, s3UploadService, applicationEventPublisher);
+	}
+
+	// TODO : 테스트코드 작성
+	@Test
+	void 앨범을_생성한다(){
+		//given
+		User mockUser = UserTestUtils.getMockUser();
+		MyPet mockUserMypet = mockUser.getMypet();
+		Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+		AlbumCreateRequest mockAlbumCreateRequest = getMockAlbumCreateRequest();
+		List<String> testAlbumImageUrl = List.of(TestConst.TEST_ALBUM_IMAGE_URL);
+		given(s3UploadService.uploadImgList(mockAlbumCreateRequest.getAlbumImages())).willReturn(testAlbumImageUrl);
+		given(userUtils.getUser()).willReturn(mockUser);
+		//when
+		AlbumInfoResponse albumInfoResponse = albumCreateUseCase.createAlbum(mockAlbumCreateRequest);
+		//then
+		then(albumSaveService).should(times(1)).saveAlbum(any(Album.class));
+		then(albumImageSaveService).should(times(1)).saveAlbumImageList(anyList(), any(Album.class));
+		then(tagSaveService).should(times(1)).saveTagList(anyList(), any(Album.class));
+
+		Assertions.assertThat(albumInfoResponse).isNotNull();
+		Assertions.assertThat(albumInfoResponse.getTitle()).isEqualTo(TestConst.TEST_ALBUM_TITLE);
+		Assertions.assertThat(albumInfoResponse.getDescription()).isEqualTo(TestConst.TEST_ALBUM_DESCRIPTION);
+		Assertions.assertThat(albumInfoResponse.getVisibility()).isEqualTo(mockAlbumCreateRequest.getVisibility());
+		Assertions.assertThat(albumInfoResponse.getChangeable()).isEqualTo(Boolean.TRUE);
+		Assertions.assertThat(albumInfoResponse.getPetName()).isEqualTo(mockUserMypet.getPetName());
+		Assertions.assertThat(albumInfoResponse.getWriterProfileImageUrl()).isEqualTo(mockUser.getProfileImageUrl());
+		Assertions.assertThat(albumInfoResponse.getCommentCount()).isEqualTo(0);
+		Assertions.assertThat(albumInfoResponse.getEmpathyCount()).isEqualTo(0);
+		Assertions.assertThat(albumInfoResponse.getEmotionTagList()).isEqualTo(mockAlbumCreateRequest.getEmotionTags());
+	}
+
+	AlbumCreateRequest getMockAlbumCreateRequest() {
+		return AlbumCreateRequest.builder()
+			.title(TestConst.TEST_ALBUM_TITLE)
+			.description(TestConst.TEST_ALBUM_DESCRIPTION)
+			.emotionTags(TestConst.EMOTION_TAG_LIST)
+			.albumImages(List.of(TestConst.TEST_MULTIPART_FILE))
+			.build();
+	}
+
+}

--- a/src/test/java/com/kusitms/samsion/domain/album/application/service/AlbumDeleteUseCaseTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/album/application/service/AlbumDeleteUseCaseTest.java
@@ -1,0 +1,55 @@
+package com.kusitms.samsion.domain.album.application.service;
+
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.kusitms.samsion.common.util.AlbumTestUtils;
+import com.kusitms.samsion.common.util.UserTestUtils;
+import com.kusitms.samsion.common.util.UserUtils;
+import com.kusitms.samsion.domain.album.domain.entity.Album;
+import com.kusitms.samsion.domain.album.domain.service.AlbumDeleteService;
+import com.kusitms.samsion.domain.album.domain.service.AlbumQueryService;
+import com.kusitms.samsion.domain.album.domain.service.AlbumValidAccessService;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AlbumDeleteUseCase 테스트")
+class AlbumDeleteUseCaseTest {
+
+	@Mock
+	UserUtils userUtils;
+	@Mock
+	AlbumQueryService albumQueryService;
+	@Mock
+	AlbumValidAccessService albumValidAccessService;
+	@Mock
+	AlbumDeleteService albumDeleteService;
+
+	AlbumDeleteUseCase albumDeleteUseCase;
+
+	@BeforeEach
+	void setUp() {
+		albumDeleteUseCase = new AlbumDeleteUseCase(userUtils, albumQueryService, albumValidAccessService, albumDeleteService);
+	}
+
+	@Test
+	void 앨범을_삭제한다() {
+		//given
+		User mockUser = UserTestUtils.getMockUser();
+		Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+		given(userUtils.getUser()).willReturn(mockUser);
+		given(albumQueryService.findAlbumById(mockAlbum.getId())).willReturn(mockAlbum);
+		//when
+		albumDeleteUseCase.deleteAlbum(mockAlbum.getId());
+		//then
+		then(albumValidAccessService).should(times(1)).validateAccess(mockAlbum, mockUser.getId());
+		then(albumDeleteService).should(times(1)).deleteAlbum(mockAlbum.getId());
+	}
+
+}

--- a/src/test/java/com/kusitms/samsion/domain/album/application/service/AlbumReadUseCaseTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/album/application/service/AlbumReadUseCaseTest.java
@@ -1,0 +1,136 @@
+package com.kusitms.samsion.domain.album.application.service;
+
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import com.kusitms.samsion.common.consts.TestConst;
+import com.kusitms.samsion.common.slice.SliceResponse;
+import com.kusitms.samsion.common.util.AlbumTestUtils;
+import com.kusitms.samsion.common.util.SliceTestUtils;
+import com.kusitms.samsion.common.util.UserTestUtils;
+import com.kusitms.samsion.common.util.UserUtils;
+import com.kusitms.samsion.domain.album.application.dto.request.AlbumSearchRequest;
+import com.kusitms.samsion.domain.album.application.dto.response.AlbumInfoResponse;
+import com.kusitms.samsion.domain.album.application.dto.response.AlbumSimpleResponse;
+import com.kusitms.samsion.domain.album.domain.entity.Album;
+import com.kusitms.samsion.domain.album.domain.entity.AlbumImage;
+import com.kusitms.samsion.domain.album.domain.entity.Tag;
+import com.kusitms.samsion.domain.album.domain.service.AlbumQueryService;
+import com.kusitms.samsion.domain.album.domain.service.AlbumValidAccessService;
+import com.kusitms.samsion.domain.comment.domain.service.CommentQueryService;
+import com.kusitms.samsion.domain.empathy.domain.service.EmpathyQueryService;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AlbumReadUseCase 테스트")
+class AlbumReadUseCaseTest {
+
+	@Mock
+	UserUtils userUtils;
+	@Mock
+	AlbumQueryService albumQueryService;
+	@Mock
+	AlbumValidAccessService albumValidAccessService;
+	@Mock
+	CommentQueryService commentQueryService;
+	@Mock
+	EmpathyQueryService empathyQueryService;
+
+	AlbumReadUseCase albumReadUseCase;
+
+	@BeforeEach
+	void setUp() {
+		albumReadUseCase = new AlbumReadUseCase(userUtils, albumQueryService, albumValidAccessService,
+			commentQueryService, empathyQueryService);
+	}
+
+	@Test
+	void 전체_앨범을_조회한다() {
+		//given
+		AlbumSearchRequest mockAlbumSearchRequest = getMockAlbumSearchRequest();
+		Pageable mockPageable = SliceTestUtils.getMockPageable();
+		User mockUser = UserTestUtils.getMockUser();
+		Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+		given(albumQueryService.findAlbumList(mockPageable, mockAlbumSearchRequest.getEmotionTagList(),
+			mockAlbumSearchRequest.getSortType()))
+			.willReturn(SliceTestUtils.getMockSlice(List.of(mockAlbum)));
+		given(commentQueryService.getCommentCountByAlbumId(mockAlbum.getId())).willReturn(TestConst.TEST_COMMENT_COUNT);
+		given(empathyQueryService.getEmpathyCountByAlbumId(mockAlbum.getId())).willReturn(TestConst.TEST_EMPATHY_COUNT);
+		//when
+		SliceResponse<AlbumSimpleResponse> albumList = albumReadUseCase.getAlbumList(mockPageable,
+			mockAlbumSearchRequest);
+		//then
+		Assertions.assertThat(albumList.getContent().get(0).getCommentCount()).isEqualTo(TestConst.TEST_COMMENT_COUNT);
+		Assertions.assertThat(albumList.getContent().get(0).getEmpathyCount()).isEqualTo(TestConst.TEST_EMPATHY_COUNT);
+		Assertions.assertThat(albumList.getContent().get(0).getAlbumId()).isEqualTo(mockAlbum.getId());
+		Assertions.assertThat(albumList.getContent().get(0).getTitle()).isEqualTo(mockAlbum.getTitle());
+		Assertions.assertThat(albumList.getContent().get(0).getImageUrl())
+			.isEqualTo(mockAlbum.getAlbumImages().get(0).getImageUrl());
+	}
+
+	@Test
+	void 나의_앨범을_조회한다() {
+		//given
+		AlbumSearchRequest mockAlbumSearchRequest = getMockAlbumSearchRequest();
+		Pageable mockPageable = SliceTestUtils.getMockPageable();
+		User mockUser = UserTestUtils.getMockUser();
+		Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+		given(userUtils.getUser()).willReturn(mockUser);
+		given(albumQueryService.findMyAlbumList(mockPageable, mockAlbumSearchRequest.getEmotionTagList(), mockAlbumSearchRequest.getSortType(), mockUser.getId()))
+			.willReturn(SliceTestUtils.getMockSlice(List.of(mockAlbum)));
+		given(commentQueryService.getCommentCountByAlbumId(mockAlbum.getId())).willReturn(TestConst.TEST_COMMENT_COUNT);
+		given(empathyQueryService.getEmpathyCountByAlbumId(mockAlbum.getId())).willReturn(TestConst.TEST_EMPATHY_COUNT);
+		//when
+		SliceResponse<AlbumSimpleResponse> albumList = albumReadUseCase.getMyAlbumList(mockPageable,
+			mockAlbumSearchRequest);
+		//then
+		Assertions.assertThat(albumList.getContent().get(0).getCommentCount()).isEqualTo(TestConst.TEST_COMMENT_COUNT);
+		Assertions.assertThat(albumList.getContent().get(0).getEmpathyCount()).isEqualTo(TestConst.TEST_EMPATHY_COUNT);
+		Assertions.assertThat(albumList.getContent().get(0).getAlbumId()).isEqualTo(mockAlbum.getId());
+		Assertions.assertThat(albumList.getContent().get(0).getTitle()).isEqualTo(mockAlbum.getTitle());
+		Assertions.assertThat(albumList.getContent().get(0).getImageUrl())
+			.isEqualTo(mockAlbum.getAlbumImages().get(0).getImageUrl());
+	}
+
+	@Test
+	void 앨범_상세_조회() {
+		//given
+		User mockUser = UserTestUtils.getMockUser();
+		Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+		given(userUtils.getUser()).willReturn(mockUser);
+		given(albumQueryService.findAlbumById(mockAlbum.getId())).willReturn(mockAlbum);
+		given(commentQueryService.getCommentCountByAlbumId(mockAlbum.getId())).willReturn(TestConst.TEST_COMMENT_COUNT);
+		given(empathyQueryService.getEmpathyCountByAlbumId(mockAlbum.getId())).willReturn(TestConst.TEST_EMPATHY_COUNT);
+		//when
+		AlbumInfoResponse albumInfoResponse = albumReadUseCase.getAlbum(mockAlbum.getId());
+		//then
+		Assertions.assertThat(albumInfoResponse.getImageUrlList()).isEqualTo(mockAlbum.getAlbumImages().stream().map(AlbumImage::getImageUrl).collect(Collectors.toList()));
+		Assertions.assertThat(albumInfoResponse.getTitle()).isEqualTo(mockAlbum.getTitle());
+		Assertions.assertThat(albumInfoResponse.getDescription()).isEqualTo(mockAlbum.getDescription());
+		Assertions.assertThat(albumInfoResponse.getVisibility()).isEqualTo(mockAlbum.getVisibility());
+		Assertions.assertThat(albumInfoResponse.getChangeable()).isEqualTo(Objects.equals(mockAlbum.getWriter().getId(), mockUser.getId()));
+		Assertions.assertThat(albumInfoResponse.getWriter()).isEqualTo(mockUser.getNickname());
+		Assertions.assertThat(albumInfoResponse.getPetName()).isEqualTo(mockUser.getMypet().getPetName());
+		Assertions.assertThat(albumInfoResponse.getWriterProfileImageUrl()).isEqualTo(mockUser.getProfileImageUrl());
+		Assertions.assertThat(albumInfoResponse.getEmotionTagList()).isEqualTo(mockAlbum.getTags().stream().map(Tag::getEmotionTag).collect(Collectors.toList()));
+		Assertions.assertThat(albumInfoResponse.getCommentCount()).isEqualTo(TestConst.TEST_COMMENT_COUNT);
+		Assertions.assertThat(albumInfoResponse.getEmpathyCount()).isEqualTo(TestConst.TEST_EMPATHY_COUNT);
+	}
+
+	AlbumSearchRequest getMockAlbumSearchRequest() {
+		return new AlbumSearchRequest(TestConst.EMOTION_TAG_LIST, TestConst.TEST_SORT_TYPE);
+	}
+
+}

--- a/src/test/java/com/kusitms/samsion/domain/album/presentation/AlbumControllerTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/album/presentation/AlbumControllerTest.java
@@ -94,17 +94,13 @@ class AlbumControllerTest extends CommonRestDocs {
 		MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(ALBUM_URL)
 			.param("size", String.valueOf(mockPageable.getPageSize()))
 			.param("page", String.valueOf(mockPageable.getPageNumber()))
-			.params(params)
-			.header(ApplicationConst.ACCESS_TOKEN_HEADER, TestConst.TEST_ACCESS_TOKEN);
+			.params(params);
 		// when
 		ResultActions result = mockMvc.perform(request);
 		// then
 		result.andExpect(status().isOk())
 			.andDo(print())
 			.andDo(restDocs.document(
-				requestHeaders(
-					headerWithName("Authorization").description("access token")
-				),
 				requestParameters(
 					parameterWithName("size").description("페이지 사이즈"),
 					parameterWithName("page").description("현재 페이지 번호"),


### PR DESCRIPTION
# Summary

---

* Album Application 계층 UseCase, Handler 테스트 작성
* Album 엔티티에서 연관관계 List 재설정시 clear 메서드 대신에 new ArrayList<>();로 설정
* AlbumQueryService get->find 로 메서드이름 변경

# Issue

---


# References

---

배열 재설정 관한 문제 참조 블로그 : https://needneo.tistory.com/141 

