### PR TITLE
[feat] 앨범 DomainService 테스트 코드 작성

### DIFF
--- a/src/main/java/com/kusitms/samsion/domain/album/application/handler/TagUpdateHandler.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/application/handler/TagUpdateHandler.java
@@ -1,20 +1,14 @@
 package com.kusitms.samsion.domain.album.application.handler;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.event.TransactionalEventListener;
-
 import com.kusitms.samsion.common.annotation.UseCase;
 import com.kusitms.samsion.domain.album.application.dto.request.TagUpdateRequest;
 import com.kusitms.samsion.domain.album.domain.entity.Album;
-import com.kusitms.samsion.domain.album.domain.entity.Tag;
 import com.kusitms.samsion.domain.album.domain.service.AlbumQueryService;
 import com.kusitms.samsion.domain.album.domain.service.TagUpdateService;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @UseCase
 @RequiredArgsConstructor
@@ -27,9 +21,6 @@ public class TagUpdateHandler {
 	@TransactionalEventListener
 	public void updateTag(TagUpdateRequest tagUpdateRequest) {
 		final Album album = albumQueryService.findAlbumById(tagUpdateRequest.getAlbumId());
-		final List<Tag> tagList = tagUpdateRequest.getTagList().stream()
-			.map(tag -> new Tag(tag, album))
-			.collect(Collectors.toList());
-		tagUpdateService.updateTag(album, tagList);
+		tagUpdateService.updateTag(album, tagUpdateRequest.getTagList());
 	}
 }

--- a/src/main/java/com/kusitms/samsion/domain/album/domain/entity/Album.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/domain/entity/Album.java
@@ -1,33 +1,19 @@
 package com.kusitms.samsion.domain.album.domain.entity;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
-
 import com.kusitms.samsion.common.domain.BaseEntity;
 import com.kusitms.samsion.domain.comment.domain.entity.Comment;
 import com.kusitms.samsion.domain.empathy.domain.entity.Empathy;
 import com.kusitms.samsion.domain.user.domain.entity.User;
-
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -72,25 +58,19 @@ public class Album extends BaseEntity {
 		this.writer = writer;
 	}
 
-	public void updateAlbum(String title, String description, Visibility visibility) {
-		updateTitle(title);
-		updateDescription(description);
-		updateVisibility(visibility);
-	}
-
-	private void updateTitle(String title) {
+	public void updateTitle(String title) {
 		if(!Objects.equals(this.title, title)&& title != null) {
 			this.title = title;
 		}
 	}
 
-	private void updateDescription(String description) {
+	public void updateDescription(String description) {
 		if(!Objects.equals(this.description, description)&& description != null) {
 			this.description = description;
 		}
 	}
 
-	private void updateVisibility(Visibility visibility) {
+	public void updateVisibility(Visibility visibility) {
 		if(!Objects.equals(this.visibility, visibility)&& visibility != null) {
 			this.visibility = visibility;
 		}

--- a/src/main/java/com/kusitms/samsion/domain/album/domain/service/AlbumUpdateService.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/domain/service/AlbumUpdateService.java
@@ -1,12 +1,10 @@
 package com.kusitms.samsion.domain.album.domain.service;
 
-import org.springframework.transaction.annotation.Transactional;
-
 import com.kusitms.samsion.common.annotation.DomainService;
 import com.kusitms.samsion.domain.album.domain.entity.Album;
 import com.kusitms.samsion.domain.album.domain.entity.Visibility;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @DomainService
 @Transactional
@@ -14,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 public class AlbumUpdateService {
 
 	public void updateAlbum(Album album, String title, String description, Visibility visibility) {
-		album.updateAlbum(title, description, visibility);
+		album.updateTitle(title);
+		album.updateDescription(description);
+		album.updateVisibility(visibility);
 	}
 }

--- a/src/main/java/com/kusitms/samsion/domain/album/domain/service/AlbumValidAccessService.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/domain/service/AlbumValidAccessService.java
@@ -1,14 +1,13 @@
 package com.kusitms.samsion.domain.album.domain.service;
 
-import java.util.Objects;
-
 import com.kusitms.samsion.common.annotation.DomainService;
 import com.kusitms.samsion.common.exception.Error;
 import com.kusitms.samsion.domain.album.domain.entity.Album;
 import com.kusitms.samsion.domain.album.domain.entity.Visibility;
 import com.kusitms.samsion.domain.album.domain.exception.AlbumAccessDeniedException;
-
 import lombok.RequiredArgsConstructor;
+
+import java.util.Objects;
 
 @DomainService
 @RequiredArgsConstructor
@@ -16,7 +15,7 @@ public class AlbumValidAccessService {
 
 	public void validateAccess(Album album, Long userId){
 		final Long albumUserId = album.getWriter().getId();
-		if(album.getVisibility() == Visibility.PRIVATE && !Objects.equals(albumUserId,userId)){
+		if(Objects.equals(album.getVisibility(), Visibility.PRIVATE) && !Objects.equals(albumUserId,userId)){
 			throw new AlbumAccessDeniedException(Error.ALBUM_ACCESS_DENIED);
 		}
 	}

--- a/src/main/java/com/kusitms/samsion/domain/album/domain/service/TagSaveService.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/domain/service/TagSaveService.java
@@ -1,16 +1,14 @@
 package com.kusitms.samsion.domain.album.domain.service;
 
-import java.util.List;
-
-import org.springframework.transaction.annotation.Transactional;
-
 import com.kusitms.samsion.common.annotation.DomainService;
 import com.kusitms.samsion.domain.album.domain.entity.Album;
 import com.kusitms.samsion.domain.album.domain.entity.EmotionTag;
 import com.kusitms.samsion.domain.album.domain.entity.Tag;
 import com.kusitms.samsion.domain.album.domain.repository.TagRepository;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @DomainService
 @Transactional
@@ -18,11 +16,6 @@ import lombok.RequiredArgsConstructor;
 public class TagSaveService {
 
 	private final TagRepository tagRepository;
-
-	public void saveTag(EmotionTag emotionTag, Album album) {
-		Tag tag = new Tag(emotionTag, album);
-		tagRepository.save(tag);
-	}
 
 	public void saveTagList(List<EmotionTag> emotionTagList, Album album){
 		emotionTagList.forEach(emotionTag -> {

--- a/src/main/java/com/kusitms/samsion/domain/album/domain/service/TagUpdateService.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/domain/service/TagUpdateService.java
@@ -1,15 +1,15 @@
 package com.kusitms.samsion.domain.album.domain.service;
 
-import java.util.List;
-
-import org.springframework.transaction.annotation.Transactional;
-
 import com.kusitms.samsion.common.annotation.DomainService;
 import com.kusitms.samsion.domain.album.domain.entity.Album;
+import com.kusitms.samsion.domain.album.domain.entity.EmotionTag;
 import com.kusitms.samsion.domain.album.domain.entity.Tag;
 import com.kusitms.samsion.domain.album.domain.repository.TagRepository;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @DomainService
 @RequiredArgsConstructor
@@ -18,7 +18,10 @@ public class TagUpdateService {
 
 	private final TagRepository tagRepository;
 
-	public void updateTag(Album album, List<Tag> tagList){
+	public void updateTag(Album album, List<EmotionTag> emotionTagList){
+		final List<Tag> tagList = emotionTagList.stream()
+				.map(tag -> new Tag(tag, album))
+				.collect(Collectors.toList());
 		album.changeAllTag(tagList);
 		tagRepository.saveAll(tagList);
 	}

--- a/src/main/resources/static/docs/Album-API.html
+++ b/src/main/resources/static/docs/Album-API.html
@@ -449,8 +449,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h4 id="Album-조회_curl_request">Curl request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/album?size=10&amp;page=0&amp;emotionTagList=HAPPY&amp;sortType=DEFAULT' -i -X GET \
-    -H 'Authorization: Bearer testAccessToken'</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/album?size=10&amp;page=0&amp;emotionTagList=HAPPY&amp;sortType=DEFAULT' -i -X GET</code></pre>
 </div>
 </div>
 </div>
@@ -459,7 +458,6 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /album?size=10&amp;page=0&amp;emotionTagList=HAPPY&amp;sortType=DEFAULT HTTP/1.1
-Authorization: Bearer testAccessToken
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -470,7 +468,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 224
+Content-Length: 213
 
 {
   "content" : [ {
@@ -491,8 +489,7 @@ Content-Length: 224
 <h4 id="Album-조회_httpie_request">HTTPie request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-bash" data-lang="bash">$ http GET 'http://localhost:8080/album?size=10&amp;page=0&amp;emotionTagList=HAPPY&amp;sortType=DEFAULT' \
-    'Authorization:Bearer testAccessToken'</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">$ http GET 'http://localhost:8080/album?size=10&amp;page=0&amp;emotionTagList=HAPPY&amp;sortType=DEFAULT'</code></pre>
 </div>
 </div>
 </div>
@@ -503,27 +500,6 @@ Content-Length: 224
 <pre class="highlight nowrap"><code></code></pre>
 </div>
 </div>
-</div>
-<div class="sect3">
-<h4 id="Album-조회_request_headers">Request headers</h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">access token</p></td>
-</tr>
-</tbody>
-</table>
 </div>
 <div class="sect3">
 <h4 id="Album-조회_request_parameters">Request parameters</h4>
@@ -695,7 +671,7 @@ albumImages
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 354
+Content-Length: 342
 
 {
   "imageUrlList" : [ "testAlbumImageUrl" ],
@@ -1204,7 +1180,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 354
+Content-Length: 342
 
 {
   "imageUrlList" : [ "testAlbumImageUrl" ],
@@ -1405,7 +1381,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 224
+Content-Length: 213
 
 {
   "content" : [ {
@@ -1578,7 +1554,7 @@ Content-Length: 224
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-05-22 17:53:54 +0900
+Last updated 2023-05-21 20:31:10 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -906,7 +906,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 181
+Content-Length: 174
 
 {
   "userNickname" : "test",
@@ -1079,7 +1079,7 @@ test
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 219
+Content-Length: 212
 
 {
   "userNickname" : "testUpdateNickname",
@@ -1211,7 +1211,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 201
+Content-Length: 192
 
 {
   "content" : [ {
@@ -1286,7 +1286,7 @@ Content-Length: 201
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /question/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer testAccessToken
-Content-Length: 53
+Content-Length: 51
 Host: localhost:8080
 
 {
@@ -1381,7 +1381,7 @@ Host: localhost:8080
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PUT /question/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer testAccessToken
-Content-Length: 53
+Content-Length: 51
 Host: localhost:8080
 
 {
@@ -1541,7 +1541,7 @@ Host: localhost:8080</code></pre>
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /album/1/comment HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: access token
-Content-Length: 48
+Content-Length: 46
 Host: localhost:8080
 
 {
@@ -1623,7 +1623,7 @@ Host: localhost:8080
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 135
+Content-Length: 130
 
 {
   "commentId" : 1,
@@ -1684,7 +1684,7 @@ Content-Length: 135
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /album/1/comment/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: access token
-Content-Length: 53
+Content-Length: 51
 Host: localhost:8080
 
 {
@@ -1770,7 +1770,7 @@ Host: localhost:8080
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 140
+Content-Length: 135
 
 {
   "commentId" : 2,
@@ -1831,7 +1831,7 @@ Content-Length: 140
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PUT /album/1/comment/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: access token
-Content-Length: 54
+Content-Length: 52
 Host: localhost:8080
 
 {
@@ -1917,7 +1917,7 @@ Host: localhost:8080
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 141
+Content-Length: 136
 
 {
   "commentId" : 1,
@@ -2124,7 +2124,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 403
+Content-Length: 387
 
 {
   "content" : [ {
@@ -2232,8 +2232,7 @@ Content-Length: 403
 <h4 id="Album-조회_curl_request"><a class="link" href="#Album-조회_curl_request">Curl request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code data-lang="bash" class="language-bash hljs">$ curl 'http://localhost:8080/album?size=10&amp;page=0&amp;emotionTagList=HAPPY&amp;sortType=DEFAULT' -i -X GET \
-    -H 'Authorization: Bearer testAccessToken'</code></pre>
+<pre class="highlightjs highlight"><code data-lang="bash" class="language-bash hljs">$ curl 'http://localhost:8080/album?size=10&amp;page=0&amp;emotionTagList=HAPPY&amp;sortType=DEFAULT' -i -X GET</code></pre>
 </div>
 </div>
 </div>
@@ -2242,7 +2241,6 @@ Content-Length: 403
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /album?size=10&amp;page=0&amp;emotionTagList=HAPPY&amp;sortType=DEFAULT HTTP/1.1
-Authorization: Bearer testAccessToken
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -2253,7 +2251,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 224
+Content-Length: 213
 
 {
   "content" : [ {
@@ -2274,8 +2272,7 @@ Content-Length: 224
 <h4 id="Album-조회_httpie_request"><a class="link" href="#Album-조회_httpie_request">HTTPie request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code data-lang="bash" class="language-bash hljs">$ http GET 'http://localhost:8080/album?size=10&amp;page=0&amp;emotionTagList=HAPPY&amp;sortType=DEFAULT' \
-    'Authorization:Bearer testAccessToken'</code></pre>
+<pre class="highlightjs highlight"><code data-lang="bash" class="language-bash hljs">$ http GET 'http://localhost:8080/album?size=10&amp;page=0&amp;emotionTagList=HAPPY&amp;sortType=DEFAULT'</code></pre>
 </div>
 </div>
 </div>
@@ -2286,27 +2283,6 @@ Content-Length: 224
 <pre class="highlightjs highlight nowrap"><code class="language-none hljs"></code></pre>
 </div>
 </div>
-</div>
-<div class="sect3">
-<h4 id="Album-조회_request_headers"><a class="link" href="#Album-조회_request_headers">Request headers</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">access token</p></td>
-</tr>
-</tbody>
-</table>
 </div>
 <div class="sect3">
 <h4 id="Album-조회_request_parameters"><a class="link" href="#Album-조회_request_parameters">Request parameters</a></h4>
@@ -2478,7 +2454,7 @@ albumImages
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 354
+Content-Length: 342
 
 {
   "imageUrlList" : [ "testAlbumImageUrl" ],
@@ -2987,7 +2963,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 354
+Content-Length: 342
 
 {
   "imageUrlList" : [ "testAlbumImageUrl" ],
@@ -3188,7 +3164,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 224
+Content-Length: 213
 
 {
   "content" : [ {
@@ -3429,7 +3405,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 379
+Content-Length: 364
 
 {
   "content" : [ {
@@ -3537,7 +3513,7 @@ Content-Length: 379
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-05-22 17:53:54 +0900
+Last updated 2023-05-22 11:55:46 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/java/com/kusitms/samsion/common/consts/TestConst.java
+++ b/src/test/java/com/kusitms/samsion/common/consts/TestConst.java
@@ -1,12 +1,12 @@
 package com.kusitms.samsion.common.consts;
 
-import java.util.List;
-
+import com.kusitms.samsion.domain.album.domain.entity.EmotionTag;
+import com.kusitms.samsion.domain.album.domain.entity.SortType;
+import com.kusitms.samsion.domain.album.domain.entity.Visibility;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.kusitms.samsion.domain.album.domain.entity.EmotionTag;
-import com.kusitms.samsion.domain.album.domain.entity.SortType;
+import java.util.List;
 
 public class TestConst {
 
@@ -49,9 +49,11 @@ public class TestConst {
 	public static final String TEST_ALBUM_TITLE = "testAlbumTitle";
 	public static final String TEST_ALBUM_DESCRIPTION = "testAlbumDescription";
 	public static final String TEST_ALBUM_IMAGE_URL = "testAlbumImageUrl";
+	public static final Visibility TEST_ALBUM_VISIBILITY = Visibility.PUBLIC;
 	public static final String TEST_UPDATE_ALBUM_TITLE = "testUpdateAlbumTitle";
 	public static final String TEST_UPDATE_ALBUM_DESCRIPTION = "testUpdateAlbumDescription";
 	public static final String TEST_UPDATE_ALBUM_IMAGE_URL = "testUpdateAlbumImageUrl";
+	public static final Visibility TEST_UPDATE_ALBUM_VISIBILITY = Visibility.PRIVATE;
 	public static final SortType TEST_SORT_TYPE = SortType.DEFAULT;
 
 	// 댓글

--- a/src/test/java/com/kusitms/samsion/common/util/AlbumTestUtils.java
+++ b/src/test/java/com/kusitms/samsion/common/util/AlbumTestUtils.java
@@ -1,16 +1,15 @@
 package com.kusitms.samsion.common.util;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.test.util.ReflectionTestUtils;
-
 import com.kusitms.samsion.common.consts.TestConst;
 import com.kusitms.samsion.domain.album.domain.entity.Album;
 import com.kusitms.samsion.domain.album.domain.entity.AlbumImage;
 import com.kusitms.samsion.domain.album.domain.entity.Tag;
-import com.kusitms.samsion.domain.album.domain.entity.Visibility;
 import com.kusitms.samsion.domain.user.domain.entity.User;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class AlbumTestUtils {
 
@@ -18,7 +17,7 @@ public class AlbumTestUtils {
 		Album mockAlbum = Album.builder()
 			.writer(mockUser)
 			.title(TestConst.TEST_ALBUM_TITLE)
-			.visibility(Visibility.PUBLIC)
+			.visibility(TestConst.TEST_ALBUM_VISIBILITY)
 			.description(TestConst.TEST_DESCRIPTION)
 			.build();
 		ReflectionTestUtils.setField(mockAlbum, "id", TestConst.TEST_ALBUM_ID);
@@ -31,7 +30,7 @@ public class AlbumTestUtils {
 	private static List<AlbumImage> getMockAlbumImageList(Album mockAlbum) {
 		AlbumImage albumImage = new AlbumImage(TestConst.TEST_ALBUM_IMAGE_URL, mockAlbum);
 		ReflectionTestUtils.setField(albumImage, "id", TestConst.TEST_ALBUM_IMAGE_ID);
-		return List.of(albumImage);
+		return new ArrayList<>(List.of(albumImage));
 	}
 
 	private static List<Tag> getMockTagList(Album mockAlbum) {
@@ -39,6 +38,6 @@ public class AlbumTestUtils {
 			.map(tag -> new Tag(tag, mockAlbum))
 			.collect(Collectors.toList());
 		tagList.forEach(tag -> ReflectionTestUtils.setField(tag, "id", TestConst.TEST_TAG_ID));
-		return tagList;
+		return new ArrayList<>(tagList);
 	}
 }

--- a/src/test/java/com/kusitms/samsion/domain/album/application/handler/TagUpdateHandlerTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/album/application/handler/TagUpdateHandlerTest.java
@@ -1,14 +1,5 @@
 package com.kusitms.samsion.domain.album.application.handler;
 
-import static org.mockito.BDDMockito.*;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import com.kusitms.samsion.common.consts.TestConst;
 import com.kusitms.samsion.common.util.AlbumTestUtils;
 import com.kusitms.samsion.common.util.UserTestUtils;
@@ -17,6 +8,14 @@ import com.kusitms.samsion.domain.album.domain.entity.Album;
 import com.kusitms.samsion.domain.album.domain.service.AlbumQueryService;
 import com.kusitms.samsion.domain.album.domain.service.TagUpdateService;
 import com.kusitms.samsion.domain.user.domain.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("TagUpdateHandler 테스트")
@@ -45,7 +44,7 @@ class TagUpdateHandlerTest {
 		tagUpdateHandler.updateTag(getMockTagUpdateRequest(mockAlbum.getId()));
 		//then
 		then(tagUpdateService).should(times(1))
-			.updateTag(eq(mockAlbum), eq(mockAlbum.getTags()));
+			.updateTag(eq(mockAlbum), eq(TestConst.EMOTION_TAG_LIST));
 	}
 
 	TagUpdateRequest getMockTagUpdateRequest(Long mockAlbumId) {

--- a/src/test/java/com/kusitms/samsion/domain/album/domain/service/AlbumDeleteServiceTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/album/domain/service/AlbumDeleteServiceTest.java
@@ -1,0 +1,43 @@
+package com.kusitms.samsion.domain.album.domain.service;
+
+import com.kusitms.samsion.common.util.AlbumTestUtils;
+import com.kusitms.samsion.common.util.UserTestUtils;
+import com.kusitms.samsion.domain.album.domain.entity.Album;
+import com.kusitms.samsion.domain.album.domain.repository.AlbumRepository;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AlbumDeleteService 테스트")
+class AlbumDeleteServiceTest {
+
+    @Mock
+    AlbumRepository albumRepository;
+
+    AlbumDeleteService albumDeleteService;
+
+    @BeforeEach
+    void setUp() {
+        albumDeleteService = new AlbumDeleteService(albumRepository);
+    }
+
+    @Test
+    void 앨범을_삭제한다() {
+        //given
+        User mockUser = UserTestUtils.getMockUser();
+        Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+        //when
+        albumDeleteService.deleteAlbum(mockAlbum.getId());
+        //then
+        then(albumRepository).should(times(1)).deleteById(mockAlbum.getId());
+    }
+
+}

--- a/src/test/java/com/kusitms/samsion/domain/album/domain/service/AlbumImageDeleteServiceTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/album/domain/service/AlbumImageDeleteServiceTest.java
@@ -1,0 +1,45 @@
+package com.kusitms.samsion.domain.album.domain.service;
+
+import com.kusitms.samsion.common.util.AlbumTestUtils;
+import com.kusitms.samsion.common.util.UserTestUtils;
+import com.kusitms.samsion.domain.album.domain.entity.Album;
+import com.kusitms.samsion.domain.album.domain.repository.AlbumImageRepository;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AlbumImageDeleteService 테스트")
+class AlbumImageDeleteServiceTest {
+
+    @Mock
+    AlbumImageRepository albumImageRepository;
+
+    AlbumImageDeleteService albumImageDeleteService;
+
+    @BeforeEach
+    void setUp() {
+        albumImageDeleteService = new AlbumImageDeleteService(albumImageRepository);
+    }
+
+    @Test
+    void 앨범_이미지를_삭제한다(){
+        //given
+        User mockUser = UserTestUtils.getMockUser();
+        Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+        //when
+        albumImageDeleteService.deleteAlbumImageList(mockAlbum);
+        //then
+        then(albumImageRepository).should(times(1)).deleteAllByAlbumId(mockAlbum.getId());
+        Assertions.assertThat(mockAlbum.getAlbumImages()).isEmpty();
+    }
+
+}

--- a/src/test/java/com/kusitms/samsion/domain/album/domain/service/AlbumImageSaveServiceTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/album/domain/service/AlbumImageSaveServiceTest.java
@@ -1,0 +1,52 @@
+package com.kusitms.samsion.domain.album.domain.service;
+
+import com.kusitms.samsion.common.consts.TestConst;
+import com.kusitms.samsion.common.util.AlbumTestUtils;
+import com.kusitms.samsion.common.util.UserTestUtils;
+import com.kusitms.samsion.domain.album.domain.entity.Album;
+import com.kusitms.samsion.domain.album.domain.entity.AlbumImage;
+import com.kusitms.samsion.domain.album.domain.repository.AlbumImageRepository;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AlbumImageSaveService 테스트")
+class AlbumImageSaveServiceTest {
+
+    @Mock
+    AlbumImageRepository albumImageRepository;
+
+    AlbumImageSaveService albumImageSaveService;
+
+    @BeforeEach
+    void setUp() {
+        albumImageSaveService = new AlbumImageSaveService(albumImageRepository);
+    }
+
+    @Test
+    void 앨범_이미지_리시트를_저장한다() {
+        //given
+        List<String> albumImageUrl = new ArrayList<>(List.of(TestConst.TEST_ALBUM_IMAGE_URL));
+        User mockUser = UserTestUtils.getMockUser();
+        Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+        //when
+        albumImageSaveService.saveAlbumImageList(albumImageUrl, mockAlbum);
+        //then
+        albumImageUrl.forEach(url -> {
+                    then(albumImageRepository).should().save(refEq(new AlbumImage(url, mockAlbum)));
+                }
+        );
+    }
+
+}

--- a/src/test/java/com/kusitms/samsion/domain/album/domain/service/AlbumImageUpdateServiceTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/album/domain/service/AlbumImageUpdateServiceTest.java
@@ -1,0 +1,53 @@
+package com.kusitms.samsion.domain.album.domain.service;
+
+import com.kusitms.samsion.common.consts.TestConst;
+import com.kusitms.samsion.common.util.AlbumTestUtils;
+import com.kusitms.samsion.common.util.UserTestUtils;
+import com.kusitms.samsion.domain.album.domain.entity.Album;
+import com.kusitms.samsion.domain.album.domain.entity.AlbumImage;
+import com.kusitms.samsion.domain.album.domain.repository.AlbumImageRepository;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AlbumImageUpdateService 테스트")
+class AlbumImageUpdateServiceTest {
+
+    @Mock
+    AlbumImageRepository albumImageRepository;
+
+    AlbumImageUpdateService albumImageUpdateService;
+
+    @BeforeEach
+    void setUp() {
+        albumImageUpdateService = new AlbumImageUpdateService(albumImageRepository);
+    }
+
+
+    @Test
+    void 앨범_이미지를_업데이트한다() {
+        //given
+        User mockUser = UserTestUtils.getMockUser();
+        Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+        List<AlbumImage> albumImageList = Stream.of(TestConst.TEST_UPDATE_ALBUM_IMAGE_URL)
+                .map(url -> new AlbumImage(url, mockAlbum))
+                .collect(Collectors.toList());
+        //when
+        albumImageUpdateService.updateAlbumImage(mockAlbum, albumImageList);
+        //then
+        then(albumImageRepository).should().saveAll(albumImageList);
+        Assertions.assertThat(mockAlbum.getAlbumImages()).isEqualTo(albumImageList);
+    }
+}

--- a/src/test/java/com/kusitms/samsion/domain/album/domain/service/AlbumQueryServiceTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/album/domain/service/AlbumQueryServiceTest.java
@@ -1,0 +1,93 @@
+package com.kusitms.samsion.domain.album.domain.service;
+
+import com.kusitms.samsion.common.consts.TestConst;
+import com.kusitms.samsion.common.util.AlbumTestUtils;
+import com.kusitms.samsion.common.util.SliceTestUtils;
+import com.kusitms.samsion.common.util.UserTestUtils;
+import com.kusitms.samsion.domain.album.domain.entity.Album;
+import com.kusitms.samsion.domain.album.domain.exception.AlbumNotFoundException;
+import com.kusitms.samsion.domain.album.domain.repository.AlbumRepository;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AlbumQueryService 테스트")
+class AlbumQueryServiceTest {
+
+    @Mock
+    AlbumRepository albumRepository;
+
+    AlbumQueryService albumQueryService;
+
+    @BeforeEach
+    void setUp() {
+        albumQueryService = new AlbumQueryService(albumRepository);
+    }
+
+    @Nested
+    class 앨범_조회_테스트 {
+        @Test
+        void 앨범을_조회한다() {
+            //given
+            User mockUser = UserTestUtils.getMockUser();
+            Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+            given(albumRepository.findById(mockAlbum.getId())).willReturn(Optional.of(mockAlbum));
+            //when
+            Album album = albumQueryService.findAlbumById(mockAlbum.getId());
+            //then
+            Assertions.assertThat(album).usingRecursiveComparison().isEqualTo(mockAlbum);
+        }
+
+        @Test
+        void 앨범이_존재하지_않으면_예외가_발생한다(){
+            //given
+            given(albumRepository.findById(TestConst.TEST_ALBUM_ID)).willReturn(Optional.empty());
+            //when
+            //then
+            Assertions.assertThatThrownBy(()-> albumQueryService.findAlbumById(TestConst.TEST_ALBUM_ID))
+                    .isInstanceOf(AlbumNotFoundException.class);
+        }
+    }
+
+    @Test
+    void 앨범_전체_조회(){
+        //given
+        User mockUser = UserTestUtils.getMockUser();
+        Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+        Pageable mockPageable = SliceTestUtils.getMockPageable();
+        given(albumRepository.findAlbumList(mockPageable, TestConst.EMOTION_TAG_LIST, TestConst.TEST_SORT_TYPE)).willReturn(SliceTestUtils.getMockSlice(List.of(mockAlbum)));
+        //when
+        Slice<Album> albumList = albumQueryService.findAlbumList(mockPageable, TestConst.EMOTION_TAG_LIST, TestConst.TEST_SORT_TYPE);
+        //then
+        Assertions.assertThat(albumList.getContent()).usingRecursiveComparison().isEqualTo(List.of(mockAlbum));
+    }
+
+    @Test
+    void 사용자_앨범_전체_조회(){
+        //given
+        User mockUser = UserTestUtils.getMockUser();
+        Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+        Pageable mockPageable = SliceTestUtils.getMockPageable();
+        given(albumRepository.findMyAlbumList(mockPageable, TestConst.EMOTION_TAG_LIST, TestConst.TEST_SORT_TYPE, mockUser.getId())).willReturn(SliceTestUtils.getMockSlice(List.of(mockAlbum)));
+        //when
+        Slice<Album> albumList = albumQueryService.findMyAlbumList(mockPageable, TestConst.EMOTION_TAG_LIST, TestConst.TEST_SORT_TYPE, mockUser.getId());
+        //then
+        Assertions.assertThat(albumList.getContent()).usingRecursiveComparison().isEqualTo(List.of(mockAlbum));
+    }
+
+
+}

--- a/src/test/java/com/kusitms/samsion/domain/album/domain/service/AlbumSaveServiceTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/album/domain/service/AlbumSaveServiceTest.java
@@ -1,0 +1,44 @@
+package com.kusitms.samsion.domain.album.domain.service;
+
+import com.kusitms.samsion.common.util.AlbumTestUtils;
+import com.kusitms.samsion.common.util.UserTestUtils;
+import com.kusitms.samsion.domain.album.domain.entity.Album;
+import com.kusitms.samsion.domain.album.domain.repository.AlbumRepository;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AlbumSaveService 테스트")
+class AlbumSaveServiceTest {
+
+    @Mock
+    AlbumRepository albumRepository;
+
+    AlbumSaveService albumSaveService;
+
+    @BeforeEach
+    void setUp() {
+        albumSaveService = new AlbumSaveService(albumRepository);
+    }
+
+    @Test
+    void 앨범을_저장한다(){
+        //given
+        User mockUser = UserTestUtils.getMockUser();
+        Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+        //when
+        albumSaveService.saveAlbum(mockAlbum);
+        //then
+        then(albumRepository).should().save(mockAlbum);
+    }
+
+
+}

--- a/src/test/java/com/kusitms/samsion/domain/album/domain/service/AlbumUpdateServiceTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/album/domain/service/AlbumUpdateServiceTest.java
@@ -1,0 +1,39 @@
+package com.kusitms.samsion.domain.album.domain.service;
+
+import com.kusitms.samsion.common.consts.TestConst;
+import com.kusitms.samsion.common.util.AlbumTestUtils;
+import com.kusitms.samsion.common.util.UserTestUtils;
+import com.kusitms.samsion.domain.album.domain.entity.Album;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AlbumUpdateService 테스트")
+class AlbumUpdateServiceTest {
+
+    AlbumUpdateService albumUpdateService;
+
+    @BeforeEach
+    void setUp() {
+        albumUpdateService = new AlbumUpdateService();
+    }
+
+    @Test
+    void 앨범을_수정한다(){
+        //given
+        User mockUser = UserTestUtils.getMockUser();
+        Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+        //when
+        albumUpdateService.updateAlbum(mockAlbum, TestConst.TEST_UPDATE_ALBUM_TITLE, TestConst.TEST_UPDATE_ALBUM_DESCRIPTION, TestConst.TEST_UPDATE_ALBUM_VISIBILITY);
+        //then
+        Assertions.assertThat(mockAlbum.getTitle()).isEqualTo(TestConst.TEST_UPDATE_ALBUM_TITLE);
+        Assertions.assertThat(mockAlbum.getDescription()).isEqualTo(TestConst.TEST_UPDATE_ALBUM_DESCRIPTION);
+        Assertions.assertThat(mockAlbum.getVisibility()).isEqualTo(TestConst.TEST_UPDATE_ALBUM_VISIBILITY);
+    }
+
+}

--- a/src/test/java/com/kusitms/samsion/domain/album/domain/service/AlbumValidAccessServiceTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/album/domain/service/AlbumValidAccessServiceTest.java
@@ -1,0 +1,82 @@
+package com.kusitms.samsion.domain.album.domain.service;
+
+import com.kusitms.samsion.common.consts.TestConst;
+import com.kusitms.samsion.common.util.AlbumTestUtils;
+import com.kusitms.samsion.common.util.UserTestUtils;
+import com.kusitms.samsion.domain.album.domain.entity.Album;
+import com.kusitms.samsion.domain.album.domain.exception.AlbumAccessDeniedException;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AlbumValidAccessService 테스트")
+class AlbumValidAccessServiceTest {
+
+    AlbumValidAccessService albumValidAccessService;
+
+    @BeforeEach
+    void setUp() {
+        albumValidAccessService = new AlbumValidAccessService();
+    }
+
+    @Nested
+    class 앨범_접근_테스트{
+        @Test
+        void PUBLIC_앨범에_작성자가_접근하면_예외가_발생하지_않는다() {
+            // given
+            User mockUser = UserTestUtils.getMockUser();
+            Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+            // when
+            // then
+            Assertions.assertThatCode(() -> albumValidAccessService.validateAccess(mockAlbum, mockUser.getId()))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void PRIVATE_앨범에_작성자가_접근하면_예외가_발생하지_않는다() {
+            // given
+            User mockUser = UserTestUtils.getMockUser();
+            Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+            mockAlbum.updateVisibility(TestConst.TEST_UPDATE_ALBUM_VISIBILITY);
+            // when
+            // then
+            Assertions.assertThatCode(() -> albumValidAccessService.validateAccess(mockAlbum, mockUser.getId()))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void PUBLIC_앨범에_작성자가_아닌_사용자가_접근하면_예외가_발생하지_않는다(){
+            //given
+            User mockUser = UserTestUtils.getMockUser();
+            User anotherMockUser = UserTestUtils.getAnotherMockUser();
+            Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+            //when
+            //then
+            Assertions.assertThatCode(() -> albumValidAccessService.validateAccess(mockAlbum, anotherMockUser.getId()))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void PRIVATE_앨범에_작성자가_아닌_사용자가_접근하면_예외가_발생하지_않는다(){
+            //given
+            User mockUser = UserTestUtils.getMockUser();
+            User anotherMockUser = UserTestUtils.getAnotherMockUser();
+            Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+            mockAlbum.updateVisibility(TestConst.TEST_UPDATE_ALBUM_VISIBILITY);
+            //when
+            //then
+            Assertions.assertThatThrownBy(() -> albumValidAccessService.validateAccess(mockAlbum, anotherMockUser.getId()))
+                    .isInstanceOf(AlbumAccessDeniedException.class);
+        }
+
+
+    }
+
+
+}

--- a/src/test/java/com/kusitms/samsion/domain/album/domain/service/TagDeleteServiceTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/album/domain/service/TagDeleteServiceTest.java
@@ -1,0 +1,44 @@
+package com.kusitms.samsion.domain.album.domain.service;
+
+import com.kusitms.samsion.common.util.AlbumTestUtils;
+import com.kusitms.samsion.common.util.UserTestUtils;
+import com.kusitms.samsion.domain.album.domain.entity.Album;
+import com.kusitms.samsion.domain.album.domain.repository.TagRepository;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TagDeleteService 테스트")
+class TagDeleteServiceTest {
+
+    @Mock
+    TagRepository tagRepository;
+
+    TagDeleteService tagDeleteService;
+
+    @BeforeEach
+    void setUp() {
+        tagDeleteService = new TagDeleteService(tagRepository);
+    }
+
+    @Test
+    void 앨범의_태그를_모두_삭제한다() {
+        // given
+        User mockUser = UserTestUtils.getMockUser();
+        Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+        // when
+        tagDeleteService.deleteTagList(mockAlbum);
+        // then
+        then(tagRepository).should().deleteAllByAlbumId(mockAlbum.getId());
+        Assertions.assertThat(mockAlbum.getTags()).isEmpty();
+    }
+
+}

--- a/src/test/java/com/kusitms/samsion/domain/album/domain/service/TagSaveServiceTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/album/domain/service/TagSaveServiceTest.java
@@ -1,0 +1,54 @@
+package com.kusitms.samsion.domain.album.domain.service;
+
+import com.kusitms.samsion.common.consts.TestConst;
+import com.kusitms.samsion.common.util.AlbumTestUtils;
+import com.kusitms.samsion.common.util.UserTestUtils;
+import com.kusitms.samsion.domain.album.domain.entity.Album;
+import com.kusitms.samsion.domain.album.domain.entity.EmotionTag;
+import com.kusitms.samsion.domain.album.domain.entity.Tag;
+import com.kusitms.samsion.domain.album.domain.repository.TagRepository;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TagSaveService 테스트")
+class TagSaveServiceTest {
+
+    @Mock
+    TagRepository tagRepository;
+
+    TagSaveService tagSaveService;
+
+    @BeforeEach
+    void setUp() {
+        tagSaveService = new TagSaveService(tagRepository);
+    }
+
+    @Test
+    void 태그를_앨범에_모두_저장한다(){
+        // given
+        User mockUser = UserTestUtils.getMockUser();
+        Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+        mockAlbum.clearAllTag();
+        List<EmotionTag> emotionTagList = TestConst.EMOTION_TAG_LIST;
+        // when
+        tagSaveService.saveTagList(emotionTagList, mockAlbum);
+        // then
+        emotionTagList.forEach(emotionTag -> {
+            then(tagRepository).should().save(any(Tag.class));
+        });
+        Assertions.assertThat(mockAlbum.getTags()).hasSize(emotionTagList.size());
+    }
+
+}

--- a/src/test/java/com/kusitms/samsion/domain/album/domain/service/TagUpdateServiceTest.java
+++ b/src/test/java/com/kusitms/samsion/domain/album/domain/service/TagUpdateServiceTest.java
@@ -1,0 +1,47 @@
+package com.kusitms.samsion.domain.album.domain.service;
+
+import com.kusitms.samsion.common.consts.TestConst;
+import com.kusitms.samsion.common.util.AlbumTestUtils;
+import com.kusitms.samsion.common.util.UserTestUtils;
+import com.kusitms.samsion.domain.album.domain.entity.Album;
+import com.kusitms.samsion.domain.album.domain.entity.EmotionTag;
+import com.kusitms.samsion.domain.album.domain.repository.TagRepository;
+import com.kusitms.samsion.domain.user.domain.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TagUpdateService 테스트")
+class TagUpdateServiceTest {
+
+    @Mock
+    TagRepository tagRepository;
+
+    TagUpdateService tagUpdateService;
+
+    @BeforeEach
+    void setUp() {
+        tagUpdateService = new TagUpdateService(tagRepository);
+    }
+
+    @Test
+    void 앨범의_태그리스트를_모두_수정한다() {
+        // given
+        User mockUser = UserTestUtils.getMockUser();
+        Album mockAlbum = AlbumTestUtils.getMockAlbum(mockUser);
+        List<EmotionTag> emotionTagList = TestConst.EMOTION_TAG_LIST;
+        // when
+        tagUpdateService.updateTag(mockAlbum, emotionTagList);
+        // then
+        then(tagRepository).should().saveAll(mockAlbum.getTags());
+    }
+
+}


### PR DESCRIPTION
# Summary

---

* 앨범 도메인 계층 서비스 테스트 코드 작성
* TagUpdateHandler 비지니스 로직 도메인 계층 서비스로직으로 분리
* 테스트에서 List의 add 메서드 오류 수정
* 앨범 전체 조회 토큰 명세 삭제 반영


# Issue

---


# References

---

테스트에서 List의 add 메서드 오류 수정 : https://duooo-story.tistory.com/64

