### PR TITLE
[fix] response dto에 동적 필드로 인한 캐싱 문제로 캐싱 비활성화

### DIFF
--- a/src/main/java/com/kusitms/samsion/domain/album/presentation/AlbumController.java
+++ b/src/main/java/com/kusitms/samsion/domain/album/presentation/AlbumController.java
@@ -1,17 +1,5 @@
 package com.kusitms.samsion.domain.album.presentation;
 
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.kusitms.samsion.common.consts.CachingStoreConst;
 import com.kusitms.samsion.common.slice.SliceResponse;
 import com.kusitms.samsion.domain.album.application.dto.request.AlbumCreateRequest;
 import com.kusitms.samsion.domain.album.application.dto.request.AlbumSearchRequest;
@@ -22,8 +10,9 @@ import com.kusitms.samsion.domain.album.application.service.AlbumCreateUseCase;
 import com.kusitms.samsion.domain.album.application.service.AlbumDeleteUseCase;
 import com.kusitms.samsion.domain.album.application.service.AlbumReadUseCase;
 import com.kusitms.samsion.domain.album.application.service.AlbumUpdateUseCase;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * TODO : 공감, 댓글, 이미지 정보도 같이 가져와야 함
@@ -64,7 +53,6 @@ public class AlbumController {
 	 * 캐시 미적용 : 3회 warmup 4회 테스트 평균 40ms
 	 * 캐시 적용 : 3회 warmup 4회 테스트 평균 20ms
 	 */
-	@Cacheable(value = CachingStoreConst.ALBUM_CACHE_NAME, key = "#albumId")
 	@GetMapping("/{albumId}")
 	public AlbumInfoResponse getAlbum(@PathVariable Long albumId){
 		return albumReadUseCase.getAlbum(albumId);
@@ -74,7 +62,6 @@ public class AlbumController {
 	 * 비동기 실행 : 100회 요청 4s82ms
 	 * 동기 실행 : 100회
 	 */
-	@CacheEvict(value = CachingStoreConst.ALBUM_CACHE_NAME, key = "#albumId")
 	@PostMapping("/{albumId}")
 	public void updateAlbum(@PathVariable Long albumId, @ModelAttribute AlbumUpdateRequest request){
 		albumUpdateUseCase.updateAlbum(albumId, request);


### PR DESCRIPTION
# Summary

---

* 반환 dto에 사용자마다 동적으로 변하는 필드가 포함되어있으면 캐싱하면 안되는데 앨범에 접속 사용자 프로필이미지, 변경 가능여부가 포함된 dto가 캐싱되고 있어 캐싱 비활성화

# Issue

---


# References

---


